### PR TITLE
Add type property to Ability class

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ This is the Pok√©mon TCG SDK PHP implementation. It is a wrapper around the Pok√
 | --------- | ---- |
 | name | string |
 | text | string |
+| type | string |
 
 #### AncientTrait
 

--- a/src/Models/Ability.php
+++ b/src/Models/Ability.php
@@ -21,6 +21,11 @@ class Ability extends Model
     private $text;
 
     /**
+     * @var string
+     */
+    private $type;
+
+    /**
      * @return string
      */
     public function getName()
@@ -50,6 +55,22 @@ class Ability extends Model
     public function setText($text)
     {
         $this->text = $text;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType()
+    {
+        return (string)$this->type;
+    }
+
+    /**
+     * @param string $type
+     */
+    public function setType($type)
+    {
+        $this->type = $type;
     }
 
 }

--- a/tests/CardTest.php
+++ b/tests/CardTest.php
@@ -74,6 +74,7 @@ class CardTest extends TestCase
         $this->assertInstanceOf(Ability::class, $card->getAbility());
         $this->assertEquals('Renegade Pulse', $card->getAbility()->getName());
         $this->assertEquals('Prevent all effects of attacks, including damage, done to this Pokémon by your opponent\'s Mega Evolution Pokémon.', $card->getAbility()->getText());
+        $this->assertEquals('Ability', $card->getAbility()->getType());
 
         /** @var Attack $attack */
         $attack = $card->getAttacks()[0];

--- a/tests/lib/fixtures/cards/find.json
+++ b/tests/lib/fixtures/cards/find.json
@@ -8,7 +8,8 @@
         "supertype": "Pokémon",
         "ability": {
             "name": "Renegade Pulse",
-            "text": "Prevent all effects of attacks, including damage, done to this Pokémon by your opponent's Mega Evolution Pokémon."
+            "text": "Prevent all effects of attacks, including damage, done to this Pokémon by your opponent's Mega Evolution Pokémon.",
+            "type": "Ability"
         },
         "hp": "170",
         "retreatCost": [


### PR DESCRIPTION
The **ability** field in the API now also has a **type** property associated with it to distinguish between Poke-Powers, Poke-Bodies, Pokemon Powers and Abilities. This commit adds on the type property to the Ability class to support this API update.
