### PR TITLE
v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
-# Composer
-vendor
-composer.lock
-
-# PhpStorm
-.idea
+/vendor/
+/composer.lock
+/composer.phar
+/.idea/
+/.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ This is the PokÃ©mon TCG SDK PHP implementation. It is a wrapper around the PokÃ
     composer require pokemon-tcg/pokemon-tcg-sdk-php
     
 ## Usage
+    
+#### Set ApiKey and options
+[See the Guzzle 7 documentation for available options.](https://docs.guzzlephp.org/en/stable/request-options.html)
+    
+    Pokemon::Options(['verify' => true]);
+    Pokemon::ApiKey('<YOUR_API_KEY_HERE>');
 
 #### Find a Card by id
 
@@ -18,22 +24,28 @@ This is the PokÃ©mon TCG SDK PHP implementation. It is a wrapper around the PokÃ
     
 #### Filter Cards via query parameters
 
-    $cards = Pokemon::Card()->where(['set' => 'generations'])->where(['supertype' => 'pokemon'])->all();
+    $cards = Pokemon::Card()->where(['set.name' => 'generations'])->where(['supertype' => 'pokemon'])->all();
+    
     $cards = Pokemon::Card()->where([
-        'set'     => 'roaring skies',
-        'subtype' => 'ex'
+        'set.name' => 'roaring skies',
+        'subtypes' => 'ex'
     ])->all();
     
-#### Find all Cards
+#### Get all Cards
 
     $cards = Pokemon::Card()->all();
     
 #### Paginate Card queries
 
     $cards = Pokemon::Card()->where([
-        'page'     => 5,
-        'pageSize' => 100
-    ])->all();
+        'set.legalities.standard' => 'legal'
+    ])->page(8)->pageSize(100)->all();
+    
+#### Get Card pagination information
+
+    $pagination = Pokemon::Card()->where([
+        'set.legalities.standard' => 'legal'
+    ])->pagination();
     
 #### Find a Set by set code
 
@@ -41,7 +53,15 @@ This is the PokÃ©mon TCG SDK PHP implementation. It is a wrapper around the PokÃ
     
 #### Filter Sets via query parameters
 
-    $set = Pokemon::Set()->where(['standardLegal' => 'true'])->all();
+    $set = Pokemon::Set()->where(['legalities.standard' => 'legal'])->all();
+    
+#### Paginate Set queries
+
+    $set = Pokemon::Set()->page(2)->pageSize(10)->all();
+    
+#### Get Set pagination information
+
+    $pagination = Pokemon::Set()->pagination();
     
 #### Get all Sets
 
@@ -59,83 +79,7 @@ This is the PokÃ©mon TCG SDK PHP implementation. It is a wrapper around the PokÃ
 
     $supertypes = Pokemon::Supertype()->all();
     
-## Models
+#### Get all Rarities
 
-#### Card
-
-| Parameter | Type |
-| --------- | ---- |
-| id | string |
-| name | string |
-| nationalPokedexNumber | int |
-| imageUrl | string |
-| imageUrlHiRes | string |
-| subtype | string |
-| supertype | string |
-| ability | Ability |
-| ancientTrait | AncientTrait |
-| hp | string |
-| number | string |
-| artist | string |
-| rarity | string |
-| series | string |
-| set | string |
-| setCode | string |
-| retreatCost | array |
-| text | array |
-| types | array |
-| attacks | array |
-| weakness | array |
-| resistance | array |
-
-#### Set
-
-| Parameter | Type |
-| --------- | ---- |
-| code | string |
-| ptcgoCode | string |
-| name | string |
-| series | string |
-| totalCards | int |
-| standardLegal | boolean |
-| releaseDate | string |
-| symbolUrl | string |
-
-#### Ability
-
-| Parameter | Type |
-| --------- | ---- |
-| name | string |
-| text | string |
-| type | string |
-
-#### AncientTrait
-
-| Parameter | Type |
-| --------- | ---- |
-| name | string |
-| text | string |
-
-#### Attack
-
-| Parameter | Type |
-| --------- | ---- |
-| cost | array |
-| name | string |
-| text | string |
-| damage | string |
-| convertedEnergyCost | int |
-
-#### Resistance
-
-| Parameter | Type |
-| --------- | ---- |
-| type | string |
-| value | string |
-
-#### Weakness
-
-| Parameter | Type |
-| --------- | ---- |
-| type | string |
-| value | string |
+    $supertypes = Pokemon::Rarity()->all();
+    

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0.x-dev"
+            "dev-master": "2.0.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,12 +15,13 @@
         }
     ],
     "require": {
-        "php": "^5.5 || ^5.6 || ^7.0",
-        "guzzlehttp/guzzle": "^6.2",
-        "doctrine/inflector": "^1.1"
+        "php": "^7.3 || ^7.4 || ^8.0",
+        "doctrine/inflector": "^2.0",
+        "guzzlehttp/guzzle": "^7.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8"
+        "phpunit/phpunit": "^9.5",
+        "dms/phpunit-arraysubset-asserts": "^0.2.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     "require": {
         "php": "^7.3 || ^7.4 || ^8.0",
         "doctrine/inflector": "^2.0",
-        "guzzlehttp/guzzle": "^7.2"
+        "guzzlehttp/guzzle": "^7.2",
+        "ext-json": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",

--- a/examples/examples.php
+++ b/examples/examples.php
@@ -1,5 +1,6 @@
 <?php
 
+use Pokemon\Models\Pagination;
 use Pokemon\Pokemon;
 
 require __DIR__ . '/../vendor/autoload.php';
@@ -11,20 +12,21 @@ require __DIR__ . '/../vendor/autoload.php';
  * 'cURL error 35: Unknown SSL protocol error in connection to api.pokemontcg.io:-9838
  * (see http://curl.haxx.se/libcurl/c/libcurl-errors.html)'
  */
-$options = ['verify' => false];
+Pokemon::Options(['verify' => false]);
+Pokemon::ApiKey('test1234');
 
 /**
  * Get a single card
  */
-//$response = Pokemon::Card($options)->find('xy7-54');
-//$response = Pokemon::Card($options)->find('xyp-XY93');
+//$response = Pokemon::Card()->find('xy7-54');
+//$response = Pokemon::Card()->find('xyp-XY93');
 //print_r($response->toArray());
 //print_r($response->toJson());
 
 /**
  * Get all cards
  */
-//$response = Pokemon::Card($options)->all();
+//$response = Pokemon::Card()->all();
 //foreach ($response as $model) {
 //    print_r($model->toArray());
 //    print_r($model->toJson());
@@ -33,8 +35,8 @@ $options = ['verify' => false];
 /**
  * Get Shaymin-EX cards
  */
-//$response = Pokemon::Card($options)->where(['name' => 'shaymin'])->where(['subtype' => 'EX'])->all();
-//$response = Pokemon::Card($options)->where(['name' => 'shaymin', 'subtype' => 'EX'])->all();
+//$response = Pokemon::Card()->where(['name' => 'shaymin'])->where(['subtype' => 'EX'])->all();
+//$response = Pokemon::Card()->where(['name' => 'shaymin', 'subtypes' => 'EX'])->orderBy('id', Pokemon::DESCENDING_ORDER)->all();
 //foreach ($response as $model) {
 //    print_r($model->toArray());
 //    print_r($model->toJson());
@@ -43,23 +45,31 @@ $options = ['verify' => false];
 /**
  * Get Vs Seeker cards
  */
-//$response = Pokemon::Card($options)->where(['name' => 'vs seeker'])->all();
+//$response = Pokemon::Card()->where(['name' => 'vs seeker'])->all();
 //foreach ($response as $model) {
 //    print_r($model->toArray());
 //    print_r($model->toJson());
 //}
 
 /**
+ * Get Pagination
+ */
+/** @var Pagination $response */
+//$response = Pokemon::Card()->pagination();
+//print_r($response->toArray());
+//print_r($response->getCount());
+
+/**
  * Get a single set
  */
-//$response = Pokemon::Set($options)->find('xy11');
+//$response = Pokemon::Set()->find('xy11');
 //print_r($response->toArray());
 //print_r($response->toJson());
 
 /**
  * Get all sets
  */
-//$response = Pokemon::Set($options)->all();
+//$response = Pokemon::Set()->all();
 //foreach ($response as $model) {
 //    print_r($model->toArray());
 //    print_r($model->toJson());
@@ -68,23 +78,23 @@ $options = ['verify' => false];
 /**
  * Get all types
  */
-//$response = Pokemon::Type($options)->all();
+//$response = Pokemon::Type()->all();
 //print_r($response);
 
 /**
  * Get all subtypes
  */
-//$response = Pokemon::Subtype($options)->all();
+//$response = Pokemon::Subtype()->all();
 //print_r($response);
 
 /**
  * Get all supertypes
  */
-//$response = Pokemon::Supertype($options)->all();
+//$response = Pokemon::Supertype()->all();
 //print_r($response);
 
 /**
  * Get all rarities
  */
-//$response = Pokemon::Rarity($options)->all();
+//$response = Pokemon::Rarity()->all();
 //print_r($response);

--- a/examples/examples.php
+++ b/examples/examples.php
@@ -17,6 +17,7 @@ $options = ['verify' => false];
  * Get a single card
  */
 //$response = Pokemon::Card($options)->find('xy7-54');
+//$response = Pokemon::Card($options)->find('xyp-XY93');
 //print_r($response->toArray());
 //print_r($response->toJson());
 
@@ -71,13 +72,19 @@ $options = ['verify' => false];
 //print_r($response);
 
 /**
+ * Get all subtypes
+ */
+//$response = Pokemon::Subtype($options)->all();
+//print_r($response);
+
+/**
  * Get all supertypes
  */
 //$response = Pokemon::Supertype($options)->all();
 //print_r($response);
 
 /**
- * Get all subtypes
+ * Get all rarities
  */
-//$response = Pokemon::Subtype($options)->all();
+//$response = Pokemon::Rarity($options)->all();
 //print_r($response);

--- a/src/Models/Ability.php
+++ b/src/Models/Ability.php
@@ -28,15 +28,15 @@ class Ability extends Model
     /**
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
-        return (string)$this->name;
+        return $this->name;
     }
 
     /**
      * @param string $name
      */
-    public function setName($name)
+    public function setName(string $name)
     {
         $this->name = $name;
     }
@@ -44,15 +44,15 @@ class Ability extends Model
     /**
      * @return string
      */
-    public function getText()
+    public function getText(): string
     {
-        return (string)$this->text;
+        return $this->text;
     }
 
     /**
      * @param string $text
      */
-    public function setText($text)
+    public function setText(string $text)
     {
         $this->text = $text;
     }
@@ -60,15 +60,15 @@ class Ability extends Model
     /**
      * @return string
      */
-    public function getType()
+    public function getType(): string
     {
-        return (string)$this->type;
+        return $this->type;
     }
 
     /**
      * @param string $type
      */
-    public function setType($type)
+    public function setType(string $type)
     {
         $this->type = $type;
     }

--- a/src/Models/AncientTrait.php
+++ b/src/Models/AncientTrait.php
@@ -23,15 +23,15 @@ class AncientTrait extends Model
     /**
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
-        return (string)$this->name;
+        return $this->name;
     }
 
     /**
      * @param string $name
      */
-    public function setName($name)
+    public function setName(string $name)
     {
         $this->name = $name;
     }
@@ -39,15 +39,15 @@ class AncientTrait extends Model
     /**
      * @return string
      */
-    public function getText()
+    public function getText(): string
     {
-        return (string)$this->text;
+        return $this->text;
     }
 
     /**
      * @param string $text
      */
-    public function setText($text)
+    public function setText(string $text)
     {
         $this->text = $text;
     }

--- a/src/Models/Attack.php
+++ b/src/Models/Attack.php
@@ -9,10 +9,6 @@ namespace Pokemon\Models;
  */
 class Attack extends Model
 {
-    /**
-     * @var array
-     */
-    private $cost;
 
     /**
      * @var string
@@ -20,14 +16,9 @@ class Attack extends Model
     private $name;
 
     /**
-     * @var string
+     * @var array
      */
-    private $text;
-
-    /**
-     * @var string
-     */
-    private $damage;
+    private $cost;
 
     /**
      * @var int
@@ -35,83 +26,93 @@ class Attack extends Model
     private $convertedEnergyCost;
 
     /**
-     * @return array
+     * @var string
      */
-    public function getCost()
-    {
-        return (array)$this->cost;
-    }
+    private $damage;
 
     /**
-     * @param array $cost
+     * @var string
      */
-    public function setCost($cost)
-    {
-        $this->cost = $cost;
-    }
+    private $text;
 
     /**
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
-        return (string)$this->name;
+        return $this->name;
     }
 
     /**
      * @param string $name
      */
-    public function setName($name)
+    public function setName(string $name)
     {
         $this->name = $name;
     }
 
     /**
-     * @return string
+     * @return array
      */
-    public function getText()
+    public function getCost(): array
     {
-        return (string)$this->text;
+        return $this->cost;
     }
 
     /**
-     * @param string $text
+     * @param array $cost
      */
-    public function setText($text)
+    public function setCost(array $cost)
     {
-        $this->text = $text;
-    }
-
-    /**
-     * @return string
-     */
-    public function getDamage()
-    {
-        return (string)$this->damage;
-    }
-
-    /**
-     * @param string $damage
-     */
-    public function setDamage($damage)
-    {
-        $this->damage = $damage;
+        $this->cost = $cost;
     }
 
     /**
      * @return int
      */
-    public function getConvertedEnergyCost()
+    public function getConvertedEnergyCost(): int
     {
-        return (int)$this->convertedEnergyCost;
+        return $this->convertedEnergyCost;
     }
 
     /**
      * @param int $convertedEnergyCost
      */
-    public function setConvertedEnergyCost($convertedEnergyCost)
+    public function setConvertedEnergyCost(int $convertedEnergyCost)
     {
         $this->convertedEnergyCost = $convertedEnergyCost;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDamage(): string
+    {
+        return $this->damage;
+    }
+
+    /**
+     * @param string $damage
+     */
+    public function setDamage(string $damage)
+    {
+        $this->damage = $damage;
+    }
+
+    /**
+     * @return string
+     */
+    public function getText(): string
+    {
+        return $this->text;
+    }
+
+    /**
+     * @param string $text
+     */
+    public function setText(string $text)
+    {
+        $this->text = $text;
     }
 
 }

--- a/src/Models/Attack.php
+++ b/src/Models/Attack.php
@@ -26,12 +26,12 @@ class Attack extends Model
     private $convertedEnergyCost;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $damage;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $text;
 
@@ -84,33 +84,33 @@ class Attack extends Model
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getDamage(): string
+    public function getDamage(): ?string
     {
         return $this->damage;
     }
 
     /**
-     * @param string $damage
+     * @param string|null $damage
      */
-    public function setDamage(string $damage)
+    public function setDamage(?string $damage)
     {
         $this->damage = $damage;
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getText(): string
+    public function getText(): ?string
     {
         return $this->text;
     }
 
     /**
-     * @param string $text
+     * @param string|null $text
      */
-    public function setText(string $text)
+    public function setText(?string $text)
     {
         $this->text = $text;
     }

--- a/src/Models/Card.php
+++ b/src/Models/Card.php
@@ -21,22 +21,22 @@ class Card extends Model
     private $name;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $supertype;
 
     /**
-     * @var array
+     * @var array|null
      */
     private $subtypes;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $hp;
 
     /**
-     * @var array
+     * @var array|null
      */
     private $types;
 
@@ -51,32 +51,32 @@ class Card extends Model
     private $evolvesTo;
 
     /**
-     * @var array
+     * @var array|null
      */
     private $abilities;
 
     /**
-     * @var array
+     * @var array|null
      */
     private $attacks;
 
     /**
-     * @var array
+     * @var array|null
      */
     private $weaknesses;
 
     /**
-     * @var array
+     * @var array|null
      */
     private $resistances;
 
     /**
-     * @var array
+     * @var array|null
      */
     private $retreatCost;
 
     /**
-     * @var int
+     * @var int|null
      */
     private $convertedRetreatCost;
 
@@ -86,37 +86,37 @@ class Card extends Model
     private $set;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $number;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $artist;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $rarity;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $flavorText;
 
     /**
-     * @var array
+     * @var array|null
      */
     private $nationalPokedexNumbers;
 
     /**
-     * @var Legalities
+     * @var Legalities|null
      */
     private $legalities;
 
     /**
-     * @var CardImages
+     * @var CardImages|null
      */
     private $images;
 
@@ -131,7 +131,7 @@ class Card extends Model
     private $ancientTrait;
 
     /**
-     * @var TCGPlayer
+     * @var TCGPlayer|null
      */
     private $tcgplayer;
 
@@ -168,65 +168,65 @@ class Card extends Model
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getSupertype(): string
+    public function getSupertype(): ?string
     {
         return $this->supertype;
     }
 
     /**
-     * @param string $supertype
+     * @param string|null $supertype
      */
-    public function setSupertype(string $supertype)
+    public function setSupertype(?string $supertype)
     {
         $this->supertype = $supertype;
     }
 
     /**
-     * @return array
+     * @return array|null
      */
-    public function getSubtypes(): array
+    public function getSubtypes(): ?array
     {
         return $this->subtypes;
     }
 
     /**
-     * @param array $subtypes
+     * @param array|null $subtypes
      */
-    public function setSubtypes(array $subtypes)
+    public function setSubtypes(?array $subtypes)
     {
         $this->subtypes = $subtypes;
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getHp(): string
+    public function getHp(): ?string
     {
         return $this->hp;
     }
 
     /**
-     * @param string $hp
+     * @param string|null $hp
      */
-    public function setHp(string $hp)
+    public function setHp(?string $hp)
     {
         $this->hp = $hp;
     }
 
     /**
-     * @return array
+     * @return array|null
      */
-    public function getTypes(): array
+    public function getTypes(): ?array
     {
         return $this->types;
     }
 
     /**
-     * @param array $types
+     * @param array|null $types
      */
-    public function setTypes(array $types)
+    public function setTypes(?array $types)
     {
         $this->types = $types;
     }
@@ -242,7 +242,7 @@ class Card extends Model
     /**
      * @param string|null $evolvesFrom
      */
-    public function setEvolvesFrom(string $evolvesFrom)
+    public function setEvolvesFrom(?string $evolvesFrom)
     {
         $this->evolvesFrom = $evolvesFrom;
     }
@@ -264,97 +264,97 @@ class Card extends Model
     }
 
     /**
-     * @return array
+     * @return array|null
      */
-    public function getAbilities(): array
+    public function getAbilities(): ?array
     {
         return $this->abilities;
     }
 
     /**
-     * @param array $abilities
+     * @param array|null $abilities
      */
-    public function setAbilities(array $abilities)
+    public function setAbilities(?array $abilities)
     {
         $this->abilities = $abilities;
     }
 
     /**
-     * @return array
+     * @return array|null
      */
-    public function getAttacks(): array
+    public function getAttacks(): ?array
     {
         return $this->attacks;
     }
 
     /**
-     * @param array $attacks
+     * @param array|null $attacks
      */
-    public function setAttacks(array $attacks)
+    public function setAttacks(?array $attacks)
     {
         $this->attacks = $attacks;
     }
 
     /**
-     * @return array
+     * @return array|null
      */
-    public function getWeaknesses(): array
+    public function getWeaknesses(): ?array
     {
         return $this->weaknesses;
     }
 
     /**
-     * @param array $weaknesses
+     * @param array|null $weaknesses
      */
-    public function setWeaknesses(array $weaknesses)
+    public function setWeaknesses(?array $weaknesses)
     {
         $this->weaknesses = $weaknesses;
     }
 
     /**
-     * @return array
+     * @return array|null
      */
-    public function getResistances(): array
+    public function getResistances(): ?array
     {
         return $this->resistances;
     }
 
     /**
-     * @param array $resistances
+     * @param array|null $resistances
      */
-    public function setResistances(array $resistances)
+    public function setResistances(?array $resistances)
     {
         $this->resistances = $resistances;
     }
 
     /**
-     * @return array
+     * @return array|null
      */
-    public function getRetreatCost(): array
+    public function getRetreatCost(): ?array
     {
         return $this->retreatCost;
     }
 
     /**
-     * @param array $retreatCost
+     * @param array|null $retreatCost
      */
-    public function setRetreatCost(array $retreatCost)
+    public function setRetreatCost(?array $retreatCost)
     {
         $this->retreatCost = $retreatCost;
     }
 
     /**
-     * @return int
+     * @return int|null
      */
-    public function getConvertedRetreatCost(): int
+    public function getConvertedRetreatCost(): ?int
     {
         return $this->convertedRetreatCost;
     }
 
     /**
-     * @param int $convertedRetreatCost
+     * @param int|null $convertedRetreatCost
      */
-    public function setConvertedRetreatCost(int $convertedRetreatCost)
+    public function setConvertedRetreatCost(?int $convertedRetreatCost)
     {
         $this->convertedRetreatCost = $convertedRetreatCost;
     }
@@ -376,113 +376,113 @@ class Card extends Model
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getNumber(): string
+    public function getNumber(): ?string
     {
         return $this->number;
     }
 
     /**
-     * @param string $number
+     * @param string|null $number
      */
-    public function setNumber(string $number)
+    public function setNumber(?string $number)
     {
         $this->number = $number;
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getArtist(): string
+    public function getArtist(): ?string
     {
         return $this->artist;
     }
 
     /**
-     * @param string $artist
+     * @param string|null $artist
      */
-    public function setArtist(string $artist)
+    public function setArtist(?string $artist)
     {
         $this->artist = $artist;
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getRarity(): string
+    public function getRarity(): ?string
     {
         return $this->rarity;
     }
 
     /**
-     * @param string $rarity
+     * @param string|null $rarity
      */
-    public function setRarity(string $rarity)
+    public function setRarity(?string $rarity)
     {
         $this->rarity = $rarity;
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getFlavorText(): string
+    public function getFlavorText(): ?string
     {
         return $this->flavorText;
     }
 
     /**
-     * @param string $flavorText
+     * @param string|null $flavorText
      */
-    public function setFlavorText(string $flavorText)
+    public function setFlavorText(?string $flavorText)
     {
         $this->flavorText = $flavorText;
     }
 
     /**
-     * @return array
+     * @return array|null
      */
-    public function getNationalPokedexNumbers(): array
+    public function getNationalPokedexNumbers(): ?array
     {
         return $this->nationalPokedexNumbers;
     }
 
     /**
-     * @param array $nationalPokedexNumbers
+     * @param array|null $nationalPokedexNumbers
      */
-    public function setNationalPokedexNumbers(array $nationalPokedexNumbers)
+    public function setNationalPokedexNumbers(?array $nationalPokedexNumbers)
     {
         $this->nationalPokedexNumbers = $nationalPokedexNumbers;
     }
 
     /**
-     * @return Legalities
+     * @return Legalities|null
      */
-    public function getLegalities(): Legalities
+    public function getLegalities(): ?Legalities
     {
         return $this->legalities;
     }
 
     /**
-     * @param Legalities $legalities
+     * @param Legalities|null $legalities
      */
-    public function setLegalities(Legalities $legalities)
+    public function setLegalities(?Legalities $legalities)
     {
         $this->legalities = $legalities;
     }
 
     /**
-     * @return CardImages
+     * @return CardImages|null
      */
-    public function getImages(): CardImages
+    public function getImages(): ?CardImages
     {
         return $this->images;
     }
 
     /**
-     * @param CardImages $images
+     * @param CardImages|null $images
      */
-    public function setImages(CardImages $images)
+    public function setImages(?CardImages $images)
     {
         $this->images = $images;
     }
@@ -498,7 +498,7 @@ class Card extends Model
     /**
      * @param array|null $rules
      */
-    public function setRules(array $rules)
+    public function setRules(?array $rules)
     {
         $this->rules = $rules;
     }
@@ -514,23 +514,23 @@ class Card extends Model
     /**
      * @param AncientTrait|null $ancientTrait
      */
-    public function setAncientTrait(AncientTrait $ancientTrait)
+    public function setAncientTrait(?AncientTrait $ancientTrait)
     {
         $this->ancientTrait = $ancientTrait;
     }
 
     /**
-     * @return TCGPlayer
+     * @return TCGPlayer|null
      */
-    public function getTcgplayer(): TCGPlayer
+    public function getTcgplayer(): ?TCGPlayer
     {
         return $this->tcgplayer;
     }
 
     /**
-     * @param TCGPlayer $tcgplayer
+     * @param TCGPlayer|null $tcgplayer
      */
-    public function setTcgplayer(TCGPlayer $tcgplayer)
+    public function setTcgplayer(?TCGPlayer $tcgplayer)
     {
         $this->tcgplayer = $tcgplayer;
     }

--- a/src/Models/Card.php
+++ b/src/Models/Card.php
@@ -21,34 +21,14 @@ class Card extends Model
     private $name;
 
     /**
-     * @var int
-     */
-    private $nationalPokedexNumber;
-
-    /**
-     * @var string
-     */
-    private $imageUrl;
-
-    /**
-     * @var string
-     */
-    private $imageUrlHiRes;
-
-    /**
-     * @var string
-     */
-    private $subtype;
-
-    /**
      * @var string
      */
     private $supertype;
 
     /**
-     * @var Ability
+     * @var array
      */
-    private $ability;
+    private $subtypes;
 
     /**
      * @var string
@@ -58,12 +38,52 @@ class Card extends Model
     /**
      * @var array
      */
-    private $retreatCost;
+    private $types;
+
+    /**
+     * @var string|null
+     */
+    private $evolvesFrom;
+
+    /**
+     * @var array|null
+     */
+    private $evolvesTo;
 
     /**
      * @var array
      */
-    private $text;
+    private $abilities;
+
+    /**
+     * @var array
+     */
+    private $attacks;
+
+    /**
+     * @var array
+     */
+    private $weaknesses;
+
+    /**
+     * @var array
+     */
+    private $resistances;
+
+    /**
+     * @var array
+     */
+    private $retreatCost;
+
+    /**
+     * @var int
+     */
+    private $convertedRetreatCost;
+
+    /**
+     * @var Set
+     */
+    private $set;
 
     /**
      * @var string
@@ -83,55 +103,50 @@ class Card extends Model
     /**
      * @var string
      */
-    private $series;
-
-    /**
-     * @var string
-     */
-    private $set;
-
-    /**
-     * @var string
-     */
-    private $setCode;
+    private $flavorText;
 
     /**
      * @var array
      */
-    private $types;
+    private $nationalPokedexNumbers;
 
     /**
-     * @var array
+     * @var Legalities
      */
-    private $attacks;
+    private $legalities;
 
     /**
-     * @var array
+     * @var CardImages
      */
-    private $weaknesses;
+    private $images;
 
     /**
-     * @var array
+     * @var array|null
      */
-    private $resistances;
+    private $rules;
 
     /**
-     * @var AncientTrait
+     * @var AncientTrait|null
      */
     private $ancientTrait;
 
     /**
+     * @var TCGPlayer
+     */
+    private $tcgplayer;
+
+    /**
      * @return string
      */
-    public function getId()
+    public function getId(): string
     {
-        return (string)$this->id;
+        return $this->id;
     }
 
     /**
      * @param string $id
      */
-    public function setId($id)
+    public function setId(string $id)
     {
         $this->id = $id;
     }
@@ -139,127 +154,63 @@ class Card extends Model
     /**
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
-        return (string)$this->name;
+        return $this->name;
     }
 
     /**
      * @param string $name
      */
-    public function setName($name)
+    public function setName(string $name)
     {
         $this->name = $name;
     }
 
     /**
-     * @return int
-     */
-    public function getNationalPokedexNumber()
-    {
-        return (int)$this->nationalPokedexNumber;
-    }
-
-    /**
-     * @param int $nationalPokedexNumber
-     */
-    public function setNationalPokedexNumber($nationalPokedexNumber)
-    {
-        $this->nationalPokedexNumber = $nationalPokedexNumber;
-    }
-
-    /**
      * @return string
      */
-    public function getImageUrl()
+    public function getSupertype(): string
     {
-        return (string)$this->imageUrl;
-    }
-
-    /**
-     * @param string $imageUrl
-     */
-    public function setImageUrl($imageUrl)
-    {
-        $this->imageUrl = $imageUrl;
-    }
-
-    /**
-     * @return string
-     */
-    public function getImageUrlHiRes()
-    {
-        return (string)$this->imageUrlHiRes;
-    }
-
-    /**
-     * @param string $imageUrlHiRes
-     */
-    public function setImageUrlHiRes($imageUrlHiRes)
-    {
-        $this->imageUrlHiRes = $imageUrlHiRes;
-    }
-
-    /**
-     * @return string
-     */
-    public function getSubtype()
-    {
-        return (string)$this->subtype;
-    }
-
-    /**
-     * @param string $subtype
-     */
-    public function setSubtype($subtype)
-    {
-        $this->subtype = $subtype;
-    }
-
-    /**
-     * @return string
-     */
-    public function getSupertype()
-    {
-        return (string)$this->supertype;
+        return $this->supertype;
     }
 
     /**
      * @param string $supertype
      */
-    public function setSupertype($supertype)
+    public function setSupertype(string $supertype)
     {
         $this->supertype = $supertype;
     }
 
     /**
-     * @return Ability
+     * @return array
      */
-    public function getAbility()
+    public function getSubtypes(): array
     {
-        return $this->ability;
+        return $this->subtypes;
     }
 
     /**
-     * @param Ability $ability
+     * @param array $subtypes
      */
-    public function setAbility($ability)
+    public function setSubtypes(array $subtypes)
     {
-        $this->ability = $ability;
+        $this->subtypes = $subtypes;
     }
 
     /**
      * @return string
      */
-    public function getHp()
+    public function getHp(): string
     {
-        return (string)$this->hp;
+        return $this->hp;
     }
 
     /**
      * @param string $hp
      */
-    public function setHp($hp)
+    public function setHp(string $hp)
     {
         $this->hp = $hp;
     }
@@ -267,159 +218,79 @@ class Card extends Model
     /**
      * @return array
      */
-    public function getRetreatCost()
+    public function getTypes(): array
     {
-        return (array)$this->retreatCost;
-    }
-
-    /**
-     * @param array $retreatCost
-     */
-    public function setRetreatCost($retreatCost)
-    {
-        $this->retreatCost = $retreatCost;
-    }
-
-    /**
-     * @return array
-     */
-    public function getText()
-    {
-        return (array)$this->text;
-    }
-
-    /**
-     * @param array $text
-     */
-    public function setText($text)
-    {
-        $this->text = $text;
-    }
-
-    /**
-     * @return string
-     */
-    public function getNumber()
-    {
-        return (string)$this->number;
-    }
-
-    /**
-     * @param string $number
-     */
-    public function setNumber($number)
-    {
-        $this->number = $number;
-    }
-
-    /**
-     * @return string
-     */
-    public function getArtist()
-    {
-        return (string)$this->artist;
-    }
-
-    /**
-     * @param string $artist
-     */
-    public function setArtist($artist)
-    {
-        $this->artist = $artist;
-    }
-
-    /**
-     * @return string
-     */
-    public function getRarity()
-    {
-        return (string)$this->rarity;
-    }
-
-    /**
-     * @param string $rarity
-     */
-    public function setRarity($rarity)
-    {
-        $this->rarity = $rarity;
-    }
-
-    /**
-     * @return string
-     */
-    public function getSeries()
-    {
-        return (string)$this->series;
-    }
-
-    /**
-     * @param string $series
-     */
-    public function setSeries($series)
-    {
-        $this->series = $series;
-    }
-
-    /**
-     * @return string
-     */
-    public function getSet()
-    {
-        return (string)$this->set;
-    }
-
-    /**
-     * @param string $set
-     */
-    public function setSet($set)
-    {
-        $this->set = $set;
-    }
-
-    /**
-     * @return string
-     */
-    public function getSetCode()
-    {
-        return (string)$this->setCode;
-    }
-
-    /**
-     * @param string $setCode
-     */
-    public function setSetCode($setCode)
-    {
-        $this->setCode = $setCode;
-    }
-
-    /**
-     * @return array
-     */
-    public function getTypes()
-    {
-        return (array)$this->types;
+        return $this->types;
     }
 
     /**
      * @param array $types
      */
-    public function setTypes($types)
+    public function setTypes(array $types)
     {
         $this->types = $types;
     }
 
     /**
+     * @return string|null
+     */
+    public function getEvolvesFrom(): ?string
+    {
+        return $this->evolvesFrom;
+    }
+
+    /**
+     * @param string|null $evolvesFrom
+     */
+    public function setEvolvesFrom(string $evolvesFrom)
+    {
+        $this->evolvesFrom = $evolvesFrom;
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getEvolvesTo(): ?array
+    {
+        return $this->evolvesTo;
+    }
+
+    /**
+     * @param array|null $evolvesTo
+     */
+    public function setEvolvesTo(?array $evolvesTo)
+    {
+        $this->evolvesTo = $evolvesTo;
+    }
+
+    /**
      * @return array
      */
-    public function getAttacks()
+    public function getAbilities(): array
     {
-        return (array)$this->attacks;
+        return $this->abilities;
+    }
+
+    /**
+     * @param array $abilities
+     */
+    public function setAbilities(array $abilities)
+    {
+        $this->abilities = $abilities;
+    }
+
+    /**
+     * @return array
+     */
+    public function getAttacks(): array
+    {
+        return $this->attacks;
     }
 
     /**
      * @param array $attacks
      */
-    public function setAttacks($attacks)
+    public function setAttacks(array $attacks)
     {
         $this->attacks = $attacks;
     }
@@ -427,15 +298,15 @@ class Card extends Model
     /**
      * @return array
      */
-    public function getWeaknesses()
+    public function getWeaknesses(): array
     {
-        return (array)$this->weaknesses;
+        return $this->weaknesses;
     }
 
     /**
      * @param array $weaknesses
      */
-    public function setWeaknesses($weaknesses)
+    public function setWeaknesses(array $weaknesses)
     {
         $this->weaknesses = $weaknesses;
     }
@@ -443,32 +314,225 @@ class Card extends Model
     /**
      * @return array
      */
-    public function getResistances()
+    public function getResistances(): array
     {
-        return (array)$this->resistances;
+        return $this->resistances;
     }
 
     /**
      * @param array $resistances
      */
-    public function setResistances($resistances)
+    public function setResistances(array $resistances)
     {
         $this->resistances = $resistances;
     }
 
     /**
-     * @return AncientTrait
+     * @return array
      */
-    public function getAncientTrait()
+    public function getRetreatCost(): array
+    {
+        return $this->retreatCost;
+    }
+
+    /**
+     * @param array $retreatCost
+     */
+    public function setRetreatCost(array $retreatCost)
+    {
+        $this->retreatCost = $retreatCost;
+    }
+
+    /**
+     * @return int
+     */
+    public function getConvertedRetreatCost(): int
+    {
+        return $this->convertedRetreatCost;
+    }
+
+    /**
+     * @param int $convertedRetreatCost
+     */
+    public function setConvertedRetreatCost(int $convertedRetreatCost)
+    {
+        $this->convertedRetreatCost = $convertedRetreatCost;
+    }
+
+    /**
+     * @return Set
+     */
+    public function getSet(): Set
+    {
+        return $this->set;
+    }
+
+    /**
+     * @param Set $set
+     */
+    public function setSet(Set $set)
+    {
+        $this->set = $set;
+    }
+
+    /**
+     * @return string
+     */
+    public function getNumber(): string
+    {
+        return $this->number;
+    }
+
+    /**
+     * @param string $number
+     */
+    public function setNumber(string $number)
+    {
+        $this->number = $number;
+    }
+
+    /**
+     * @return string
+     */
+    public function getArtist(): string
+    {
+        return $this->artist;
+    }
+
+    /**
+     * @param string $artist
+     */
+    public function setArtist(string $artist)
+    {
+        $this->artist = $artist;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRarity(): string
+    {
+        return $this->rarity;
+    }
+
+    /**
+     * @param string $rarity
+     */
+    public function setRarity(string $rarity)
+    {
+        $this->rarity = $rarity;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFlavorText(): string
+    {
+        return $this->flavorText;
+    }
+
+    /**
+     * @param string $flavorText
+     */
+    public function setFlavorText(string $flavorText)
+    {
+        $this->flavorText = $flavorText;
+    }
+
+    /**
+     * @return array
+     */
+    public function getNationalPokedexNumbers(): array
+    {
+        return $this->nationalPokedexNumbers;
+    }
+
+    /**
+     * @param array $nationalPokedexNumbers
+     */
+    public function setNationalPokedexNumbers(array $nationalPokedexNumbers)
+    {
+        $this->nationalPokedexNumbers = $nationalPokedexNumbers;
+    }
+
+    /**
+     * @return Legalities
+     */
+    public function getLegalities(): Legalities
+    {
+        return $this->legalities;
+    }
+
+    /**
+     * @param Legalities $legalities
+     */
+    public function setLegalities(Legalities $legalities)
+    {
+        $this->legalities = $legalities;
+    }
+
+    /**
+     * @return CardImages
+     */
+    public function getImages(): CardImages
+    {
+        return $this->images;
+    }
+
+    /**
+     * @param CardImages $images
+     */
+    public function setImages(CardImages $images)
+    {
+        $this->images = $images;
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getRules(): ?array
+    {
+        return $this->rules;
+    }
+
+    /**
+     * @param array|null $rules
+     */
+    public function setRules(array $rules)
+    {
+        $this->rules = $rules;
+    }
+
+    /**
+     * @return AncientTrait|null
+     */
+    public function getAncientTrait(): ?AncientTrait
     {
         return $this->ancientTrait;
     }
 
     /**
-     * @param AncientTrait $ancientTrait
+     * @param AncientTrait|null $ancientTrait
      */
     public function setAncientTrait(AncientTrait $ancientTrait)
     {
         $this->ancientTrait = $ancientTrait;
     }
+
+    /**
+     * @return TCGPlayer
+     */
+    public function getTcgplayer(): TCGPlayer
+    {
+        return $this->tcgplayer;
+    }
+
+    /**
+     * @param TCGPlayer $tcgplayer
+     */
+    public function setTcgplayer(TCGPlayer $tcgplayer)
+    {
+        $this->tcgplayer = $tcgplayer;
+    }
+
 }

--- a/src/Models/Card.php
+++ b/src/Models/Card.php
@@ -41,6 +41,11 @@ class Card extends Model
     private $types;
 
     /**
+     * @var array|null
+     */
+    private $rules;
+
+    /**
      * @var string|null
      */
     private $evolvesFrom;
@@ -119,11 +124,6 @@ class Card extends Model
      * @var CardImages|null
      */
     private $images;
-
-    /**
-     * @var array|null
-     */
-    private $rules;
 
     /**
      * @var AncientTrait|null
@@ -229,6 +229,22 @@ class Card extends Model
     public function setTypes(?array $types)
     {
         $this->types = $types;
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getRules(): ?array
+    {
+        return $this->rules;
+    }
+
+    /**
+     * @param array|null $rules
+     */
+    public function setRules(?array $rules)
+    {
+        $this->rules = $rules;
     }
 
     /**
@@ -485,22 +501,6 @@ class Card extends Model
     public function setImages(?CardImages $images)
     {
         $this->images = $images;
-    }
-
-    /**
-     * @return array|null
-     */
-    public function getRules(): ?array
-    {
-        return $this->rules;
-    }
-
-    /**
-     * @param array|null $rules
-     */
-    public function setRules(?array $rules)
-    {
-        $this->rules = $rules;
     }
 
     /**

--- a/src/Models/CardImages.php
+++ b/src/Models/CardImages.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Pokemon\Models;
+
+/**
+ * Class CardImages
+ *
+ * @package Pokemon\Models
+ */
+class CardImages extends Model
+{
+
+    /**
+     * @var string
+     */
+    private $small;
+
+    /**
+     * @var string
+     */
+    private $large;
+
+    /**
+     * @return string
+     */
+    public function getSmall(): string
+    {
+        return $this->small;
+    }
+
+    /**
+     * @param string $small
+     */
+    public function setSmall(string $small)
+    {
+        $this->small = $small;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLarge(): string
+    {
+        return $this->large;
+    }
+
+    /**
+     * @param string $large
+     */
+    public function setLarge(string $large)
+    {
+        $this->large = $large;
+    }
+
+}

--- a/src/Models/CardImages.php
+++ b/src/Models/CardImages.php
@@ -11,43 +11,43 @@ class CardImages extends Model
 {
 
     /**
-     * @var string
+     * @var string|null
      */
     private $small;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $large;
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getSmall(): string
+    public function getSmall(): ?string
     {
         return $this->small;
     }
 
     /**
-     * @param string $small
+     * @param string|null $small
      */
-    public function setSmall(string $small)
+    public function setSmall(?string $small)
     {
         $this->small = $small;
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getLarge(): string
+    public function getLarge(): ?string
     {
         return $this->large;
     }
 
     /**
-     * @param string $large
+     * @param string|null $large
      */
-    public function setLarge(string $large)
+    public function setLarge(?string $large)
     {
         $this->large = $large;
     }

--- a/src/Models/Legalities.php
+++ b/src/Models/Legalities.php
@@ -36,7 +36,7 @@ class Legalities extends Model
     /**
      * @param string|null $standard
      */
-    public function setStandard(string $standard)
+    public function setStandard(?string $standard)
     {
         $this->standard = $standard;
     }
@@ -52,7 +52,7 @@ class Legalities extends Model
     /**
      * @param string|null $unlimited
      */
-    public function setUnlimited(string $unlimited)
+    public function setUnlimited(?string $unlimited)
     {
         $this->unlimited = $unlimited;
     }
@@ -68,7 +68,7 @@ class Legalities extends Model
     /**
      * @param string|null $expanded
      */
-    public function setExpanded(string $expanded)
+    public function setExpanded(?string $expanded)
     {
         $this->expanded = $expanded;
     }

--- a/src/Models/Legalities.php
+++ b/src/Models/Legalities.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Pokemon\Models;
+
+/**
+ * Class Legalities
+ *
+ * @package Pokemon\Models
+ */
+class Legalities extends Model
+{
+
+    /**
+     * @var string|null
+     */
+    private $standard;
+
+    /**
+     * @var string|null
+     */
+    private $unlimited;
+
+    /**
+     * @var string|null
+     */
+    private $expanded;
+
+    /**
+     * @return string|null
+     */
+    public function getStandard(): ?string
+    {
+        return $this->standard;
+    }
+
+    /**
+     * @param string|null $standard
+     */
+    public function setStandard(string $standard)
+    {
+        $this->standard = $standard;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getUnlimited(): ?string
+    {
+        return $this->unlimited;
+    }
+
+    /**
+     * @param string|null $unlimited
+     */
+    public function setUnlimited(string $unlimited)
+    {
+        $this->unlimited = $unlimited;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getExpanded(): ?string
+    {
+        return $this->expanded;
+    }
+
+    /**
+     * @param string|null $expanded
+     */
+    public function setExpanded(string $expanded)
+    {
+        $this->expanded = $expanded;
+    }
+
+}

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -2,8 +2,10 @@
 
 namespace Pokemon\Models;
 
-use Doctrine\Common\Inflector\Inflector;
+use Doctrine\Inflector\Inflector;
+use Doctrine\Inflector\InflectorFactory;
 use ReflectionClass;
+use ReflectionException;
 use ReflectionProperty;
 use stdClass;
 
@@ -21,17 +23,24 @@ class Model
     protected $methods;
 
     /**
+     * @var Inflector
+     */
+    protected $inflector;
+
+    /**
      * Model constructor.
      */
     public function __construct()
     {
         $this->methods = array_flip(get_class_methods(get_class($this)));
+        $this->inflector = InflectorFactory::create()->build();
 
         return $this;
     }
 
     /**
      * @return array
+     * @throws ReflectionException
      */
     public function getAttributes()
     {
@@ -74,7 +83,7 @@ class Model
     protected function parse($attribute, $value)
     {
         if (is_object($value)) {
-            $class = '\\Pokemon\\Models\\' . ucfirst(Inflector::singularize($attribute));
+            $class = '\\Pokemon\\Models\\' . ucfirst($this->inflector->singularize($attribute));
             if (class_exists($class)) {
                 /** @var Model $model */
                 $model = new $class;
@@ -88,6 +97,7 @@ class Model
 
     /**
      * @return array
+     * @throws ReflectionException
      */
     public function toArray()
     {
@@ -117,6 +127,7 @@ class Model
      * @param mixed $value
      *
      * @return mixed
+     * @throws ReflectionException
      */
     protected function valueToArray($value)
     {
@@ -129,6 +140,7 @@ class Model
 
     /**
      * @return string
+     * @throws ReflectionException
      */
     public function toJson()
     {

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -77,7 +77,7 @@ class Model
 
     /**
      * @param string $attribute
-     * @param mixed  $value
+     * @param mixed $value
      *
      * @return mixed|Model
      */

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -2,7 +2,6 @@
 
 namespace Pokemon\Models;
 
-use Doctrine\Inflector\Inflector;
 use Doctrine\Inflector\InflectorFactory;
 use ReflectionClass;
 use ReflectionException;
@@ -23,17 +22,11 @@ class Model
     protected $methods;
 
     /**
-     * @var Inflector
-     */
-    protected $inflector;
-
-    /**
      * Model constructor.
      */
     public function __construct()
     {
         $this->methods = array_flip(get_class_methods(get_class($this)));
-        $this->inflector = InflectorFactory::create()->build();
 
         return $this;
     }
@@ -82,8 +75,26 @@ class Model
      */
     protected function parse($attribute, $value)
     {
+        $inflector = InflectorFactory::create()->build();
+
         if (is_object($value)) {
-            $class = '\\Pokemon\\Models\\' . ucfirst($this->inflector->singularize($attribute));
+            switch ($attribute) {
+                case 'images':
+                    $class = get_class($this) . 'Images';
+                    break;
+
+                case 'tcgplayer':
+                    $class = '\\Pokemon\\Models\\TCGPlayer';
+                    break;
+
+                case 'legalities':
+                    $class = '\\Pokemon\\Models\\Legalities';
+                    break;
+
+                default:
+                    $class = '\\Pokemon\\Models\\' . ucfirst($inflector->singularize($attribute));
+            }
+
             if (class_exists($class)) {
                 /** @var Model $model */
                 $model = new $class;

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -60,7 +60,15 @@ class Model
                 $value = $this->parse($attribute, $value);
             }
 
-            $method = 'set' . ucfirst($attribute);
+            switch ($attribute) {
+                case '1stEditionNormal':
+                    $method = 'setFirstEditionNormal';
+                    break;
+
+                default:
+                    $method = 'set' . ucfirst($attribute);
+            }
+
             if (isset($this->methods[$method])) {
                 $this->{$method}($value);
             }
@@ -83,12 +91,16 @@ class Model
                     $class = get_class($this) . 'Images';
                     break;
 
-                case 'tcgplayer':
-                    $class = '\\Pokemon\\Models\\TCGPlayer';
-                    break;
-
                 case 'legalities':
                     $class = '\\Pokemon\\Models\\Legalities';
+                    break;
+
+                case 'prices':
+                    $class = '\\Pokemon\\Models\\Prices';
+                    break;
+
+                case 'tcgplayer':
+                    $class = '\\Pokemon\\Models\\TCGPlayer';
                     break;
 
                 default:

--- a/src/Models/Pagination.php
+++ b/src/Models/Pagination.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Pokemon\Models;
+
+use DivisionByZeroError;
+
+/**
+ * Class Pagination
+ *
+ * @package Pokemon\Models
+ */
+class Pagination
+{
+
+    /**
+     * @var int|null
+     */
+    private $page;
+
+    /**
+     * @var int|null
+     */
+    private $pageSize;
+
+    /**
+     * @var int|null
+     */
+    private $count;
+
+    /**
+     * @var int|null
+     */
+    private $totalCount;
+
+    /**
+     * @return int|null
+     */
+    public function getPage(): int
+    {
+        return $this->page;
+    }
+
+    /**
+     * @param int|null $page
+     */
+    public function setPage(int $page)
+    {
+        $this->page = $page;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getPageSize(): int
+    {
+        return $this->pageSize;
+    }
+
+    /**
+     * @param int|null $pageSize
+     */
+    public function setPageSize(int $pageSize)
+    {
+        $this->pageSize = $pageSize;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getCount(): int
+    {
+        return $this->count;
+    }
+
+    /**
+     * @param int|null $count
+     */
+    public function setCount(int $count)
+    {
+        $this->count = $count;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getTotalCount(): int
+    {
+        return $this->totalCount;
+    }
+
+    /**
+     * @param int|null $totalCount
+     */
+    public function setTotalCount(int $totalCount)
+    {
+        $this->totalCount = $totalCount;
+    }
+
+    /**
+     * @return int
+     */
+    public function getTotalPages(): int
+    {
+        try {
+            return ceil($this->totalCount / $this->pageSize);
+        } catch (DivisionByZeroError $e) {
+            return 1;
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray(): array
+    {
+        return [
+            'page' => $this->page,
+            'pageSize' => $this->pageSize,
+            'count' => $this->count,
+            'totalCount' => $this->totalCount,
+            'totalPages' => $this->getTotalPages(),
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    public function toJson()
+    {
+        return json_encode($this->toArray());
+    }
+
+}

--- a/src/Models/PriceTiers.php
+++ b/src/Models/PriceTiers.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Pokemon\Models;
+
+/**
+ * class PriceTiers
+ *
+ * @package Pokemon\Models
+ */
+class PriceTiers extends Model
+{
+
+    /**
+     * @var float|null
+     */
+    private $low;
+
+    /**
+     * @var float|null
+     */
+    private $mid;
+
+    /**
+     * @var float|null
+     */
+    private $high;
+
+    /**
+     * @var float|null
+     */
+    private $market;
+
+    /**
+     * @var float|null
+     */
+    private $directLow;
+
+    /**
+     * @return float|null
+     */
+    public function getLow(): ?float
+    {
+        return $this->low;
+    }
+
+    /**
+     * @param float|null $low
+     */
+    public function setLow(?float $low)
+    {
+        $this->low = $low;
+    }
+
+    /**
+     * @return float|null
+     */
+    public function getMid(): ?float
+    {
+        return $this->mid;
+    }
+
+    /**
+     * @param float|null $mid
+     */
+    public function setMid(?float $mid)
+    {
+        $this->mid = $mid;
+    }
+
+    /**
+     * @return float|null
+     */
+    public function getHigh(): ?float
+    {
+        return $this->high;
+    }
+
+    /**
+     * @param float|null $high
+     */
+    public function setHigh(?float $high)
+    {
+        $this->high = $high;
+    }
+
+    /**
+     * @return float|null
+     */
+    public function getMarket(): ?float
+    {
+        return $this->market;
+    }
+
+    /**
+     * @param float|null $market
+     */
+    public function setMarket(?float $market)
+    {
+        $this->market = $market;
+    }
+
+    /**
+     * @return float|null
+     */
+    public function getDirectLow(): ?float
+    {
+        return $this->directLow;
+    }
+
+    /**
+     * @param float|null $directLow
+     */
+    public function setDirectLow(?float $directLow)
+    {
+        $this->directLow = $directLow;
+    }
+
+}

--- a/src/Models/Prices.php
+++ b/src/Models/Prices.php
@@ -96,7 +96,7 @@ class Prices extends Model
 
     /**
      * @param string $attribute
-     * @param mixed  $value
+     * @param mixed $value
      *
      * @return mixed|Model
      */

--- a/src/Models/Prices.php
+++ b/src/Models/Prices.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Pokemon\Models;
+
+/**
+ * class Prices
+ *
+ * @package Pokemon\Models
+ */
+class Prices extends Model
+{
+
+    /**
+     * @var PriceTiers|null
+     */
+    private $normal;
+
+    /**
+     * @var PriceTiers|null
+     */
+    private $holofoil;
+
+    /**
+     * @var PriceTiers|null
+     */
+    private $reverseHolofoil;
+
+    /**
+     * @var PriceTiers|null
+     */
+    private $firstEditionNormal;
+
+    /**
+     * @return PriceTiers|null
+     */
+    public function getNormal(): ?PriceTiers
+    {
+        return $this->normal;
+    }
+
+    /**
+     * @param PriceTiers|null $normal
+     */
+    public function setNormal(?PriceTiers $normal)
+    {
+        $this->normal = $normal;
+    }
+
+    /**
+     * @return PriceTiers|null
+     */
+    public function getHolofoil(): ?PriceTiers
+    {
+        return $this->holofoil;
+    }
+
+    /**
+     * @param PriceTiers|null $holofoil
+     */
+    public function setHolofoil(?PriceTiers $holofoil)
+    {
+        $this->holofoil = $holofoil;
+    }
+
+    /**
+     * @return PriceTiers|null
+     */
+    public function getReverseHolofoil(): ?PriceTiers
+    {
+        return $this->reverseHolofoil;
+    }
+
+    /**
+     * @param PriceTiers|null $reverseHolofoil
+     */
+    public function setReverseHolofoil(?PriceTiers $reverseHolofoil)
+    {
+        $this->reverseHolofoil = $reverseHolofoil;
+    }
+
+    /**
+     * @return PriceTiers|null
+     */
+    public function getFirstEditionNormal(): ?PriceTiers
+    {
+        return $this->firstEditionNormal;
+    }
+
+    /**
+     * @param PriceTiers|null $firstEditionNormal
+     */
+    public function setFirstEditionNormal(?PriceTiers $firstEditionNormal)
+    {
+        $this->firstEditionNormal = $firstEditionNormal;
+    }
+
+    /**
+     * @param string $attribute
+     * @param mixed  $value
+     *
+     * @return mixed|Model
+     */
+    protected function parse($attribute, $value)
+    {
+        $tiers = new PriceTiers();
+        $tiers->fill($value);
+
+        return $tiers;
+    }
+
+}

--- a/src/Models/Resistance.php
+++ b/src/Models/Resistance.php
@@ -23,15 +23,15 @@ class Resistance extends Model
     /**
      * @return string
      */
-    public function getType()
+    public function getType(): string
     {
-        return (string)$this->type;
+        return $this->type;
     }
 
     /**
      * @param string $type
      */
-    public function setType($type)
+    public function setType(string $type)
     {
         $this->type = $type;
     }
@@ -39,15 +39,15 @@ class Resistance extends Model
     /**
      * @return string
      */
-    public function getValue()
+    public function getValue(): string
     {
-        return (string)$this->value;
+        return $this->value;
     }
 
     /**
      * @param string $value
      */
-    public function setValue($value)
+    public function setValue(string $value)
     {
         $this->value = $value;
     }

--- a/src/Models/Set.php
+++ b/src/Models/Set.php
@@ -13,12 +13,7 @@ class Set extends Model
     /**
      * @var string
      */
-    private $code;
-
-    /**
-     * @var string
-     */
-    private $ptcgoCode;
+    private $id;
 
     /**
      * @var string
@@ -33,17 +28,22 @@ class Set extends Model
     /**
      * @var int
      */
-    private $totalCards;
+    private $printedTotal;
 
     /**
-     * @var boolean
+     * @var int
      */
-    private $standardLegal;
+    private $total;
 
     /**
-     * @var boolean
+     * @var Legalities
      */
-    private $expandedLegal;
+    private $legalities;
+
+    /**
+     * @var string
+     */
+    private $ptcgoCode;
 
     /**
      * @var string
@@ -53,57 +53,41 @@ class Set extends Model
     /**
      * @var string
      */
-    private $symbolUrl;
+    private $updatedAt;
 
     /**
-     * @var string
+     * @var SetImages
      */
-    private $logoUrl;
-
-    /**
-     * @return string
-     */
-    public function getCode()
-    {
-        return (string)$this->code;
-    }
-
-    /**
-     * @param string $code
-     */
-    public function setCode($code)
-    {
-        $this->code = $code;
-    }
+    private $images;
 
     /**
      * @return string
      */
-    public function getPtcgoCode()
+    public function getId(): string
     {
-        return (string)$this->ptcgoCode;
+        return $this->id;
     }
 
     /**
-     * @param string $ptcgoCode
+     * @param string $id
      */
-    public function setPtcgoCode($ptcgoCode)
+    public function setId(string $id)
     {
-        $this->ptcgoCode = $ptcgoCode;
+        $this->id = $id;
     }
 
     /**
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
-        return (string)$this->name;
+        return $this->name;
     }
 
     /**
      * @param string $name
      */
-    public function setName($name)
+    public function setName(string $name)
     {
         $this->name = $name;
     }
@@ -111,15 +95,15 @@ class Set extends Model
     /**
      * @return string
      */
-    public function getSeries()
+    public function getSeries(): string
     {
-        return (string)$this->series;
+        return $this->series;
     }
 
     /**
      * @param string $series
      */
-    public function setSeries($series)
+    public function setSeries(string $series)
     {
         $this->series = $series;
     }
@@ -127,63 +111,79 @@ class Set extends Model
     /**
      * @return int
      */
-    public function getTotalCards()
+    public function getPrintedTotal(): int
     {
-        return (int)$this->totalCards;
+        return $this->printedTotal;
     }
 
     /**
-     * @param int $totalCards
+     * @param int $printedTotal
      */
-    public function setTotalCards($totalCards)
+    public function setPrintedTotal(int $printedTotal)
     {
-        $this->totalCards = $totalCards;
+        $this->printedTotal = $printedTotal;
     }
 
     /**
-     * @return boolean
+     * @return int
      */
-    public function isStandardLegal()
+    public function getTotal(): int
     {
-        return (boolean)$this->standardLegal;
+        return $this->total;
     }
 
     /**
-     * @param boolean $standardLegal
+     * @param int $total
      */
-    public function setStandardLegal($standardLegal)
+    public function setTotal(int $total)
     {
-        $this->standardLegal = $standardLegal;
+        $this->total = $total;
     }
 
     /**
-     * @return boolean
+     * @return Legalities
      */
-    public function isExpandedLegal()
+    public function getLegalities(): Legalities
     {
-        return (boolean)$this->expandedLegal;
+        return $this->legalities;
     }
 
     /**
-     * @param boolean $expandedLegal
+     * @param Legalities $legalities
      */
-    public function setExpandedLegal($expandedLegal)
+    public function setLegalities(Legalities $legalities)
     {
-        $this->expandedLegal = $expandedLegal;
+        $this->legalities = $legalities;
     }
 
     /**
      * @return string
      */
-    public function getReleaseDate()
+    public function getPtcgoCode(): string
     {
-        return (string)$this->releaseDate;
+        return $this->ptcgoCode;
+    }
+
+    /**
+     * @param string $ptcgoCode
+     */
+    public function setPtcgoCode(string $ptcgoCode)
+    {
+        $this->ptcgoCode = $ptcgoCode;
+    }
+
+    /**
+     * @return string
+     */
+    public function getReleaseDate(): string
+    {
+        return $this->releaseDate;
     }
 
     /**
      * @param string $releaseDate
      */
-    public function setReleaseDate($releaseDate)
+    public function setReleaseDate(string $releaseDate)
     {
         $this->releaseDate = $releaseDate;
     }
@@ -191,33 +191,33 @@ class Set extends Model
     /**
      * @return string
      */
-    public function getSymbolUrl()
+    public function getUpdatedAt(): string
     {
-        return (string)$this->symbolUrl;
+        return $this->updatedAt;
     }
 
     /**
-     * @param string $symbolUrl
+     * @param string $updatedAt
      */
-    public function setSymbolUrl($symbolUrl)
+    public function setUpdatedAt(string $updatedAt)
     {
-        $this->symbolUrl = $symbolUrl;
+        $this->updatedAt = $updatedAt;
     }
 
     /**
-     * @return string
+     * @return SetImages
      */
-    public function getLogoUrl()
+    public function getImages(): SetImages
     {
-        return (string)$this->logoUrl;
+        return $this->images;
     }
 
     /**
-     * @param string $logoUrl
+     * @param SetImages $images
      */
-    public function setLogoUrl($logoUrl)
+    public function setImages(SetImages $images)
     {
-        $this->logoUrl = $logoUrl;
+        $this->images = $images;
     }
 
 }

--- a/src/Models/Set.php
+++ b/src/Models/Set.php
@@ -36,27 +36,27 @@ class Set extends Model
     private $total;
 
     /**
-     * @var Legalities
+     * @var Legalities|null
      */
     private $legalities;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $ptcgoCode;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $releaseDate;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $updatedAt;
 
     /**
-     * @var SetImages
+     * @var SetImages|null
      */
     private $images;
 
@@ -141,81 +141,81 @@ class Set extends Model
     }
 
     /**
-     * @return Legalities
+     * @return Legalities|null
      */
-    public function getLegalities(): Legalities
+    public function getLegalities(): ?Legalities
     {
         return $this->legalities;
     }
 
     /**
-     * @param Legalities $legalities
+     * @param Legalities|null $legalities
      */
-    public function setLegalities(Legalities $legalities)
+    public function setLegalities(?Legalities $legalities)
     {
         $this->legalities = $legalities;
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getPtcgoCode(): string
+    public function getPtcgoCode(): ?string
     {
         return $this->ptcgoCode;
     }
 
     /**
-     * @param string $ptcgoCode
+     * @param string|null $ptcgoCode
      */
-    public function setPtcgoCode(string $ptcgoCode)
+    public function setPtcgoCode(?string $ptcgoCode)
     {
         $this->ptcgoCode = $ptcgoCode;
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getReleaseDate(): string
+    public function getReleaseDate(): ?string
     {
         return $this->releaseDate;
     }
 
     /**
-     * @param string $releaseDate
+     * @param string|null $releaseDate
      */
-    public function setReleaseDate(string $releaseDate)
+    public function setReleaseDate(?string $releaseDate)
     {
         $this->releaseDate = $releaseDate;
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getUpdatedAt(): string
+    public function getUpdatedAt(): ?string
     {
         return $this->updatedAt;
     }
 
     /**
-     * @param string $updatedAt
+     * @param string|null $updatedAt
      */
-    public function setUpdatedAt(string $updatedAt)
+    public function setUpdatedAt(?string $updatedAt)
     {
         $this->updatedAt = $updatedAt;
     }
 
     /**
-     * @return SetImages
+     * @return SetImages|null
      */
-    public function getImages(): SetImages
+    public function getImages(): ?SetImages
     {
         return $this->images;
     }
 
     /**
-     * @param SetImages $images
+     * @param SetImages|null $images
      */
-    public function setImages(SetImages $images)
+    public function setImages(?SetImages $images)
     {
         $this->images = $images;
     }

--- a/src/Models/SetImages.php
+++ b/src/Models/SetImages.php
@@ -11,43 +11,43 @@ class SetImages extends Model
 {
 
     /**
-     * @var string
+     * @var string|null
      */
     private $symbol;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $logo;
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getSymbol(): string
+    public function getSymbol(): ?string
     {
         return $this->symbol;
     }
 
     /**
-     * @param string $symbol
+     * @param string|null $symbol
      */
-    public function setSymbol(string $symbol)
+    public function setSymbol(?string $symbol)
     {
         $this->symbol = $symbol;
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getLogo(): string
+    public function getLogo(): ?string
     {
         return $this->logo;
     }
 
     /**
-     * @param string $logo
+     * @param string|null $logo
      */
-    public function setLogo(string $logo)
+    public function setLogo(?string $logo)
     {
         $this->logo = $logo;
     }

--- a/src/Models/SetImages.php
+++ b/src/Models/SetImages.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Pokemon\Models;
+
+/**
+ * Class SetImages
+ *
+ * @package Pokemon\Models
+ */
+class SetImages extends Model
+{
+
+    /**
+     * @var string
+     */
+    private $symbol;
+
+    /**
+     * @var string
+     */
+    private $logo;
+
+    /**
+     * @return string
+     */
+    public function getSymbol(): string
+    {
+        return $this->symbol;
+    }
+
+    /**
+     * @param string $symbol
+     */
+    public function setSymbol(string $symbol)
+    {
+        $this->symbol = $symbol;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLogo(): string
+    {
+        return $this->logo;
+    }
+
+    /**
+     * @param string $logo
+     */
+    public function setLogo(string $logo)
+    {
+        $this->logo = $logo;
+    }
+
+}

--- a/src/Models/TCGPlayer.php
+++ b/src/Models/TCGPlayer.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Pokemon\Models;
+
+/**
+ * Class TCGPlayer
+ *
+ * @package Pokemon\Models
+ */
+class TCGPlayer extends Model
+{
+
+    /**
+     * @var string
+     */
+    private $url;
+
+    /**
+     * @var string
+     */
+    private $updatedAt;
+
+    /**
+     * @var array
+     */
+    private $prices;
+
+    /**
+     * @return string
+     */
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+
+    /**
+     * @param string $url
+     */
+    public function setUrl(string $url)
+    {
+        $this->url = $url;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUpdatedAt(): string
+    {
+        return $this->updatedAt;
+    }
+
+    /**
+     * @param string $updatedAt
+     */
+    public function setUpdatedAt(string $updatedAt)
+    {
+        $this->updatedAt = $updatedAt;
+    }
+
+//    /**
+//     * @return array
+//     */
+//    public function getPrices(): array
+//    {
+//        return $this->prices;
+//    }
+//
+//    /**
+//     * @param array $prices
+//     */
+//    public function setPrices(array $prices)
+//    {
+//        $this->prices = $prices;
+//    }
+
+}

--- a/src/Models/TCGPlayer.php
+++ b/src/Models/TCGPlayer.php
@@ -16,61 +16,61 @@ class TCGPlayer extends Model
     private $url;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $updatedAt;
 
     /**
-     * @var array
+     * @var Prices|null
      */
     private $prices;
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getUrl(): string
+    public function getUrl(): ?string
     {
         return $this->url;
     }
 
     /**
-     * @param string $url
+     * @param string|null $url
      */
-    public function setUrl(string $url)
+    public function setUrl(?string $url)
     {
         $this->url = $url;
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getUpdatedAt(): string
+    public function getUpdatedAt(): ?string
     {
         return $this->updatedAt;
     }
 
     /**
-     * @param string $updatedAt
+     * @param string|null $updatedAt
      */
-    public function setUpdatedAt(string $updatedAt)
+    public function setUpdatedAt(?string $updatedAt)
     {
         $this->updatedAt = $updatedAt;
     }
 
-//    /**
-//     * @return array
-//     */
-//    public function getPrices(): array
-//    {
-//        return $this->prices;
-//    }
-//
-//    /**
-//     * @param array $prices
-//     */
-//    public function setPrices(array $prices)
-//    {
-//        $this->prices = $prices;
-//    }
+    /**
+     * @return Prices|null
+     */
+    public function getPrices(): ?Prices
+    {
+        return $this->prices;
+    }
+
+    /**
+     * @param Prices|null $prices
+     */
+    public function setPrices(?Prices $prices)
+    {
+        $this->prices = $prices;
+    }
 
 }

--- a/src/Models/Weakness.php
+++ b/src/Models/Weakness.php
@@ -23,15 +23,15 @@ class Weakness extends Model
     /**
      * @return string
      */
-    public function getType()
+    public function getType(): string
     {
-        return (string)$this->type;
+        return $this->type;
     }
 
     /**
      * @param string $type
      */
-    public function setType($type)
+    public function setType(string $type)
     {
         $this->type = $type;
     }
@@ -39,15 +39,15 @@ class Weakness extends Model
     /**
      * @return string
      */
-    public function getValue()
+    public function getValue(): string
     {
-        return (string)$this->value;
+        return $this->value;
     }
 
     /**
      * @param string $value
      */
-    public function setValue($value)
+    public function setValue(string $value)
     {
         $this->value = $value;
     }

--- a/src/Pokemon.php
+++ b/src/Pokemon.php
@@ -17,108 +17,120 @@ class Pokemon
 
     const API_URL = 'https://api.pokemontcg.io/v2/';
 
+    const DESCENDING_ORDER = -1;
+    const ASCENDING_ORDER = 1;
+
+    /**
+     * @var string|null
+     */
+    private static $apiKey = null;
+
+    /**
+     * @var array
+     */
+    private static $options = [];
+
     /**
      * @var null|array
      */
     private static $cache = [
         'resources' => [],
-        'options'   => [],
+        'options' => [],
     ];
 
     /**
+     * @param string|null $apiKey
+     */
+    public static function ApiKey(?string $apiKey)
+    {
+        self::$apiKey = $apiKey;
+    }
+
+    /**
      * @param array $options
-     *
+     */
+    public static function Options(array $options)
+    {
+        self::$options = $options;
+    }
+
+    /**
      * @return QueriableResourceInterface
      */
-    public static function Card(array $options = []): QueriableResourceInterface
+    public static function Card(): QueriableResourceInterface
     {
-        return self::getQueriableResource('cards', $options);
+        return self::getQueriableResource('cards');
     }
 
     /**
-     * @param array $options
-     *
      * @return QueriableResourceInterface
      */
-    public static function Set(array $options = []): QueriableResourceInterface
+    public static function Set(): QueriableResourceInterface
     {
-        return self::getQueriableResource('sets', $options);
+        return self::getQueriableResource('sets');
     }
 
     /**
-     * @param array $options
-     *
      * @return ResourceInterface
      */
-    public static function Type(array $options = []): ResourceInterface
+    public static function Type(): ResourceInterface
     {
-        return self::getJsonResource('types', $options);
+        return self::getJsonResource('types');
     }
 
     /**
-     * @param array $options
-     *
      * @return ResourceInterface
      */
-    public static function Subtype(array $options = []): ResourceInterface
+    public static function Subtype(): ResourceInterface
     {
-        return self::getJsonResource('subtypes', $options);
+        return self::getJsonResource('subtypes');
     }
 
     /**
-     * @param array $options
-     *
      * @return ResourceInterface
      */
-    public static function Supertype(array $options = []): ResourceInterface
+    public static function Supertype(): ResourceInterface
     {
-        return self::getJsonResource('supertypes', $options);
+        return self::getJsonResource('supertypes');
     }
 
     /**
-     * @param array $options
-     *
      * @return ResourceInterface
      */
-    public static function Rarity(array $options = []): ResourceInterface
+    public static function Rarity(): ResourceInterface
     {
-        return self::getJsonResource('rarities', $options);
+        return self::getJsonResource('rarities');
     }
 
     /**
      * @param string $type
-     * @param array  $options
-     *
      * @return QueriableResourceInterface
      */
-    private static function getQueriableResource($type, array $options = []): QueriableResourceInterface
+    private static function getQueriableResource($type): QueriableResourceInterface
     {
-        if (!array_key_exists($type, self::$cache['resources']) || self::haveOptionsBeenUpdated($type, $options)) {
-            self::$cache['options'][$type] = $options;
-            self::$cache['resources'][$type] = new QueryableResource($type, $options);
+        if (!array_key_exists($type, self::$cache['resources']) || self::haveOptionsBeenUpdated($type, self::$options)) {
+            self::$cache['options'][$type] = self::$options;
+            self::$cache['resources'][$type] = new QueryableResource($type, self::$options, self::$apiKey);
         }
         return self::$cache['resources'][$type];
     }
 
     /**
      * @param string $type
-     * @param array  $options
-     *
      * @return ResourceInterface
      */
-    private static function getJsonResource($type, array $options = []): ResourceInterface
+    private static function getJsonResource($type): ResourceInterface
     {
-        if (!array_key_exists($type, self::$cache['resources']) || self::haveOptionsBeenUpdated($type, $options)) {
-            self::$cache['options'][$type] = $options;
-            self::$cache['resources'][$type] = new JsonResource($type, $options);
+        if (!array_key_exists($type, self::$cache['resources']) || self::haveOptionsBeenUpdated($type, self::$options)) {
+            self::$cache['options'][$type] = self::$options;
+            self::$cache['resources'][$type] = new JsonResource($type, self::$options, self::$apiKey);
         }
         return self::$cache['resources'][$type];
     }
 
     /**
      * @param string $key
-     * @param array  $options
-     *
+     * @param array $options
      * @return bool
      */
     private static function haveOptionsBeenUpdated($key, array $options = []): bool

--- a/src/Pokemon.php
+++ b/src/Pokemon.php
@@ -5,7 +5,7 @@ namespace Pokemon;
 use Pokemon\Resources\Interfaces\QueriableResourceInterface;
 use Pokemon\Resources\Interfaces\ResourceInterface;
 use Pokemon\Resources\JsonResource;
-use Pokemon\Resources\QueriableResource;
+use Pokemon\Resources\QueryableResource;
 
 /**
  * Class Pokemon
@@ -15,7 +15,7 @@ use Pokemon\Resources\QueriableResource;
 class Pokemon
 {
 
-    const API_URL = 'https://api.pokemontcg.io/v1/';
+    const API_URL = 'https://api.pokemontcg.io/v2/';
 
     /**
      * @var null|array
@@ -85,7 +85,7 @@ class Pokemon
     {
         if (!array_key_exists($type, self::$cache['resources']) || self::haveOptionsBeenUpdated($type, $options)) {
             self::$cache['options'][$type] = $options;
-            self::$cache['resources'][$type] = new QueriableResource($type, $options);
+            self::$cache['resources'][$type] = new QueryableResource($type, $options);
         }
         return self::$cache['resources'][$type];
     }

--- a/src/Pokemon.php
+++ b/src/Pokemon.php
@@ -30,7 +30,7 @@ class Pokemon
      *
      * @return QueriableResourceInterface
      */
-    public static function Card(array $options = [])
+    public static function Card(array $options = []): QueriableResourceInterface
     {
         return self::getQueriableResource('cards', $options);
     }
@@ -40,7 +40,7 @@ class Pokemon
      *
      * @return QueriableResourceInterface
      */
-    public static function Set(array $options = [])
+    public static function Set(array $options = []): QueriableResourceInterface
     {
         return self::getQueriableResource('sets', $options);
     }
@@ -50,7 +50,7 @@ class Pokemon
      *
      * @return ResourceInterface
      */
-    public static function Type(array $options = [])
+    public static function Type(array $options = []): ResourceInterface
     {
         return self::getJsonResource('types', $options);
     }
@@ -60,7 +60,17 @@ class Pokemon
      *
      * @return ResourceInterface
      */
-    public static function Supertype(array $options = [])
+    public static function Subtype(array $options = []): ResourceInterface
+    {
+        return self::getJsonResource('subtypes', $options);
+    }
+
+    /**
+     * @param array $options
+     *
+     * @return ResourceInterface
+     */
+    public static function Supertype(array $options = []): ResourceInterface
     {
         return self::getJsonResource('supertypes', $options);
     }
@@ -70,9 +80,9 @@ class Pokemon
      *
      * @return ResourceInterface
      */
-    public static function Subtype(array $options = [])
+    public static function Rarity(array $options = []): ResourceInterface
     {
-        return self::getJsonResource('subtypes', $options);
+        return self::getJsonResource('rarities', $options);
     }
 
     /**
@@ -81,7 +91,7 @@ class Pokemon
      *
      * @return QueriableResourceInterface
      */
-    private static function getQueriableResource($type, array $options = [])
+    private static function getQueriableResource($type, array $options = []): QueriableResourceInterface
     {
         if (!array_key_exists($type, self::$cache['resources']) || self::haveOptionsBeenUpdated($type, $options)) {
             self::$cache['options'][$type] = $options;
@@ -96,7 +106,7 @@ class Pokemon
      *
      * @return ResourceInterface
      */
-    private static function getJsonResource($type, array $options = [])
+    private static function getJsonResource($type, array $options = []): ResourceInterface
     {
         if (!array_key_exists($type, self::$cache['resources']) || self::haveOptionsBeenUpdated($type, $options)) {
             self::$cache['options'][$type] = $options;
@@ -111,7 +121,7 @@ class Pokemon
      *
      * @return bool
      */
-    private static function haveOptionsBeenUpdated($key, array $options = [])
+    private static function haveOptionsBeenUpdated($key, array $options = []): bool
     {
         if (array_key_exists($key, self::$cache)) {
             return (self::$cache[$key] != $options);

--- a/src/Resources/JsonResource.php
+++ b/src/Resources/JsonResource.php
@@ -61,7 +61,7 @@ class JsonResource implements ResourceInterface
     /**
      * @return Request
      */
-    protected function prepare()
+    protected function prepare(): Request
     {
         return new Request($this->method, $this->resource);
     }
@@ -71,70 +71,29 @@ class JsonResource implements ResourceInterface
      *
      * @return mixed
      */
-    protected function getResponseData(ResponseInterface $response)
+    protected function getResponseData(ResponseInterface $response): mixed
     {
         return json_decode($response->getBody()->getContents());
     }
 
     /**
-     * @param stdClass $data
+     * @param stdClass $response
      *
      * @return array
      */
-    protected function transformAll(stdClass $data)
+    protected function transformAll(stdClass $response): array
     {
-        return $this->getFirstProperty($data);
-    }
-
-    /**
-     * @param stdClass $data
-     *
-     * @return string|null
-     */
-    protected function getFirstPropertyName(stdClass $data)
-    {
-        $attributes = get_object_vars($data);
-
-        return (count($attributes) > 0) ? array_keys($attributes)[0] : null;
-    }
-
-    /**
-     * @param stdClass $data
-     *
-     * @return mixed
-     */
-    protected function getFirstProperty(stdClass $data)
-    {
-        return $data->{$this->getFirstPropertyName($data)};
-    }
-
-    /**
-     * @param stdClass $data
-     *
-     * @return Model|null
-     */
-    protected function transform(stdClass $data)
-    {
-        $model = null;
-
-        $class = '\\Pokemon\\Models\\' . ucfirst($this->inflector->singularize($this->resource));
-        if (class_exists($class)) {
-            /** @var Model $model */
-            $model = new $class;
-            $model->fill($data);
-        }
-
-        return $model;
+        return $response->data;
     }
 
     /**
      * @return array
      * @throws GuzzleException
      */
-    public function all()
+    public function all(): array
     {
-        $data = $this->getResponseData($this->client->send($this->prepare()));
+        $response = $this->getResponseData($this->client->send($this->prepare()));
 
-        return $this->transformAll($data);
+        return $this->transformAll($response);
     }
 }

--- a/src/Resources/JsonResource.php
+++ b/src/Resources/JsonResource.php
@@ -2,7 +2,10 @@
 
 namespace Pokemon\Resources;
 
+use Doctrine\Inflector\Inflector;
+use Doctrine\Inflector\InflectorFactory;
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Psr7\Request;
 use Pokemon\Pokemon;
 use Pokemon\Resources\Interfaces\ResourceInterface;
@@ -33,6 +36,11 @@ class JsonResource implements ResourceInterface
     protected $uri;
 
     /**
+     * @var Inflector
+     */
+    protected $inflector;
+
+    /**
      * Request constructor.
      *
      * @param string $uri
@@ -46,6 +54,7 @@ class JsonResource implements ResourceInterface
         ];
         $this->uri = $uri;
         $this->client = new Client(array_merge($defaults, $options));
+        $this->inflector = InflectorFactory::create()->build();
     }
 
     /**
@@ -100,6 +109,7 @@ class JsonResource implements ResourceInterface
 
     /**
      * @return array
+     * @throws GuzzleException
      */
     public function all()
     {

--- a/src/Resources/JsonResource.php
+++ b/src/Resources/JsonResource.php
@@ -7,7 +7,6 @@ use Doctrine\Inflector\InflectorFactory;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Psr7\Request;
-use Pokemon\Models\Model;
 use Pokemon\Pokemon;
 use Pokemon\Resources\Interfaces\ResourceInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -45,14 +44,22 @@ class JsonResource implements ResourceInterface
      * Request constructor.
      *
      * @param string $resource
-     * @param array  $options
+     * @param array $options
+     * @param string|null $apiKey
      */
-    public function __construct($resource, array $options = [])
+    public function __construct($resource, array $options = [], ?string $apiKey = null)
     {
         $defaults = [
             'base_uri' => Pokemon::API_URL,
-            'verify'   => false,
+            'verify' => false,
         ];
+
+        if (!empty($apiKey)) {
+            $defaults['headers'] = [
+                'X-Api-Key' => $apiKey,
+            ];
+        }
+
         $this->resource = $resource;
         $this->client = new Client(array_merge($defaults, $options));
         $this->inflector = InflectorFactory::create()->build();

--- a/src/Resources/QueriableResource.php
+++ b/src/Resources/QueriableResource.php
@@ -2,8 +2,9 @@
 
 namespace Pokemon\Resources;
 
-use Doctrine\Common\Inflector\Inflector;
+use Doctrine\Inflector\InflectorFactory;
 use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Psr7\Request;
 use InvalidArgumentException;
 use Pokemon\Models\Model;
@@ -85,7 +86,9 @@ class QueriableResource extends JsonResource implements QueriableResourceInterfa
         $model = null;
         $name = !empty($className) ? $className : $this->getFirstPropertyName($data);
         $data = !empty($className) ? $data : $this->getFirstProperty($data);
-        $class = '\\Pokemon\\Models\\' . ucfirst(Inflector::singularize($name));
+
+        $infelctor = InflectorFactory::create()->build();
+        $class = '\\Pokemon\\Models\\' . ucfirst($infelctor->singularize($name));
         if (class_exists($class)) {
             /** @var Model $model */
             $model = new $class;
@@ -100,6 +103,7 @@ class QueriableResource extends JsonResource implements QueriableResourceInterfa
      *
      * @return Model|null
      * @throws InvalidArgumentException
+     * @throws GuzzleException
      */
     public function find($identifier)
     {

--- a/src/Resources/QueriableResource.php
+++ b/src/Resources/QueriableResource.php
@@ -2,7 +2,6 @@
 
 namespace Pokemon\Resources;
 
-use Doctrine\Inflector\InflectorFactory;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Psr7\Request;
@@ -86,9 +85,7 @@ class QueriableResource extends JsonResource implements QueriableResourceInterfa
         $model = null;
         $name = !empty($className) ? $className : $this->getFirstPropertyName($data);
         $data = !empty($className) ? $data : $this->getFirstProperty($data);
-
-        $infelctor = InflectorFactory::create()->build();
-        $class = '\\Pokemon\\Models\\' . ucfirst($infelctor->singularize($name));
+        $class = '\\Pokemon\\Models\\' . ucfirst($this->inflector->singularize($name));
         if (class_exists($class)) {
             /** @var Model $model */
             $model = new $class;

--- a/src/Resources/QueryableResource.php
+++ b/src/Resources/QueryableResource.php
@@ -7,6 +7,8 @@ use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Psr7\Request;
 use InvalidArgumentException;
 use Pokemon\Models\Model;
+use Pokemon\Models\Pagination;
+use Pokemon\Pokemon;
 use Pokemon\Resources\Interfaces\QueriableResourceInterface;
 use stdClass;
 
@@ -18,10 +20,28 @@ use stdClass;
 class QueryableResource extends JsonResource implements QueriableResourceInterface
 {
 
+    const DEFAULT_PAGE = 1;
+    const DEFAULT_PAGE_SIZE = 250;
+
     /**
      * @var array
      */
     protected $query = [];
+
+    /**
+     * @var int
+     */
+    protected $page = self::DEFAULT_PAGE;
+
+    /**
+     * @var int
+     */
+    protected $pageSize = self::DEFAULT_PAGE_SIZE;
+
+    /**
+     * @var array
+     */
+    protected $orderBy = [];
 
     /**
      * @var string|null
@@ -36,21 +56,43 @@ class QueryableResource extends JsonResource implements QueriableResourceInterfa
         $uri = $this->resource;
 
         if (!empty($this->identifier)) {
-            $uri = $this->resource . '/' . $this->identifier;
+            $uri = $uri . '/' . $this->identifier;
             $this->identifier = null;
+
+            return new Request($this->method, $uri);
         }
 
+        $queryParams = [];
         if (!empty($this->query)) {
-            $uri = $this->resource . '?' . http_build_query($this->query);
+            $query = array_map(function ($attribute, $value) {
+                return $attribute . ':"' . $value . '"';
+            }, array_keys($this->query), $this->query);
+
+            $queryParams['q'] = implode(' ', $query);
             $this->query = [];
         }
 
+        if ($this->page > self::DEFAULT_PAGE) {
+            $queryParams['page'] = $this->page;
+            $this->page = self::DEFAULT_PAGE;
+        }
+
+        if ($this->pageSize !== self::DEFAULT_PAGE_SIZE) {
+            $queryParams['pageSize'] = $this->pageSize;
+            $this->pageSize = self::DEFAULT_PAGE_SIZE;
+        }
+
+        if (!empty($this->orderBy)) {
+            $queryParams['orderBy'] = implode(',', $this->orderBy);
+            $this->orderBy = [];
+        }
+
+        $uri = $this->resource . '?' . http_build_query($queryParams);
         return new Request($this->method, $uri);
     }
 
     /**
      * @param array $query
-     *
      * @return QueriableResourceInterface
      */
     public function where(array $query): QueriableResourceInterface
@@ -61,8 +103,41 @@ class QueryableResource extends JsonResource implements QueriableResourceInterfa
     }
 
     /**
+     * @param int $page
+     * @return QueriableResourceInterface
+     */
+    public function page(int $page): QueriableResourceInterface
+    {
+        $this->page = $page;
+
+        return $this;
+    }
+
+    /**
+     * @param int $pageSize
+     * @return QueriableResourceInterface
+     */
+    public function pageSize(int $pageSize): QueriableResourceInterface
+    {
+        $this->pageSize = $pageSize;
+
+        return $this;
+    }
+
+    /**
+     * @param string $attribute
+     * @param int $direction
+     * @return QueriableResourceInterface
+     */
+    public function orderBy(string $attribute, int $direction = Pokemon::ASCENDING_ORDER): QueriableResourceInterface
+    {
+        $this->orderBy[] = $direction === Pokemon::DESCENDING_ORDER ? '-' . $attribute : $attribute;
+
+        return $this;
+    }
+
+    /**
      * @param stdClass $data
-     *
      * @return Model|null
      */
     protected function transform(stdClass $data): ?Model
@@ -81,7 +156,6 @@ class QueryableResource extends JsonResource implements QueriableResourceInterfa
 
     /**
      * @param stdClass $response
-     *
      * @return array
      */
     protected function transformAll(stdClass $response): array
@@ -93,7 +167,6 @@ class QueryableResource extends JsonResource implements QueriableResourceInterfa
 
     /**
      * @param string $identifier
-     *
      * @return Model|null
      * @throws InvalidArgumentException
      * @throws GuzzleException
@@ -108,6 +181,23 @@ class QueryableResource extends JsonResource implements QueriableResourceInterfa
         }
 
         return $this->transform($response->data);
+    }
+
+    /**
+     * @return Pagination
+     * @throws GuzzleException
+     */
+    public function pagination(): Pagination
+    {
+        $response = $this->getResponseData($this->client->send($this->prepare()));
+
+        $pagination = new Pagination();
+        $pagination->setPage($response->page);
+        $pagination->setPageSize($response->pageSize);
+        $pagination->setCount($response->count);
+        $pagination->setTotalCount($response->totalCount);
+
+        return $pagination;
     }
 
 }

--- a/src/Resources/QueryableResource.php
+++ b/src/Resources/QueryableResource.php
@@ -31,7 +31,7 @@ class QueryableResource extends JsonResource implements QueriableResourceInterfa
     /**
      * @return Request
      */
-    protected function prepare()
+    protected function prepare(): Request
     {
         $uri = $this->resource;
 
@@ -53,7 +53,7 @@ class QueryableResource extends JsonResource implements QueriableResourceInterfa
      *
      * @return QueriableResourceInterface
      */
-    public function where(array $query)
+    public function where(array $query): QueriableResourceInterface
     {
         $this->query = array_merge($this->query, $query);
 
@@ -63,13 +63,32 @@ class QueryableResource extends JsonResource implements QueriableResourceInterfa
     /**
      * @param stdClass $data
      *
+     * @return Model|null
+     */
+    protected function transform(stdClass $data): ?Model
+    {
+        $model = null;
+        $class = '\\Pokemon\\Models\\' . ucfirst($this->inflector->singularize($this->resource));
+
+        if (class_exists($class)) {
+            /** @var Model $model */
+            $model = new $class;
+            $model->fill($data);
+        }
+
+        return $model;
+    }
+
+    /**
+     * @param stdClass $response
+     *
      * @return array
      */
-    protected function transformAll(stdClass $data)
+    protected function transformAll(stdClass $response): array
     {
         return array_map(function ($data) {
             return $this->transform($data);
-        }, $this->getFirstProperty($data));
+        }, $response->data);
     }
 
     /**
@@ -79,7 +98,7 @@ class QueryableResource extends JsonResource implements QueriableResourceInterfa
      * @throws InvalidArgumentException
      * @throws GuzzleException
      */
-    public function find($identifier)
+    public function find($identifier): ?Model
     {
         $this->identifier = $identifier;
         try {

--- a/tests/CardTest.php
+++ b/tests/CardTest.php
@@ -24,7 +24,7 @@ class CardTest extends TestCase
     /**
      * Run before tests
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -41,7 +41,7 @@ class CardTest extends TestCase
      */
     public function testFindWithInvalidIdThrowsException()
     {
-        $this->setExpectedException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         Pokemon::Card($this->clientOptions)->find('invalid');
     }
 

--- a/tests/CardTest.php
+++ b/tests/CardTest.php
@@ -4,6 +4,14 @@ use GuzzleHttp\Psr7\Response;
 use Pokemon\Models\Ability;
 use Pokemon\Models\Attack;
 use Pokemon\Models\Card;
+use Pokemon\Models\CardImages;
+use Pokemon\Models\Legalities;
+use Pokemon\Models\Pagination;
+use Pokemon\Models\Prices;
+use Pokemon\Models\PriceTiers;
+use Pokemon\Models\Set;
+use Pokemon\Models\SetImages;
+use Pokemon\Models\TCGPlayer;
 use Pokemon\Models\Weakness;
 use Pokemon\Pokemon;
 
@@ -16,7 +24,7 @@ class CardTest extends TestCase
     /**
      * @return string
      */
-    protected function fixtureDirectory()
+    protected function fixtureDirectory(): string
     {
         return 'cards';
     }
@@ -32,6 +40,7 @@ class CardTest extends TestCase
             new Response(404),
             new Response(200, [], $this->getFixture('find.json')),
             new Response(200, [], $this->getFixture('page.json')),
+            new Response(200, [], $this->getFixture('page.json')),
             new Response(200, [], $this->getFixture('filtered.json')),
         ]);
     }
@@ -39,69 +48,119 @@ class CardTest extends TestCase
     /**
      * Test invalid card id
      */
-    public function testFindWithInvalidIdThrowsException()
+    public function testFindWithInvalidIdThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        Pokemon::Card($this->clientOptions)->find('invalid');
+        Pokemon::Options($this->clientOptions);
+        Pokemon::Card()->find('invalid');
     }
 
     /**
      * Test find card
      */
-    public function testFindReturnsOneCard()
+    public function testFindReturnsOneCard(): void
     {
         /** @var Card $card */
-        $card = Pokemon::Card($this->clientOptions)->find('xy7-57');
+        Pokemon::Options($this->clientOptions);
+        $card = Pokemon::Card()->find('xy7-57');
 
         $this->assertInstanceOf(Card::class, $card);
         $this->assertEquals('xy7-57', $card->getId());
         $this->assertEquals('Giratina-EX', $card->getName());
-        $this->assertEquals(487, $card->getNationalPokedexNumber());
-        $this->assertEquals('https://images.pokemontcg.io/xy7/54.png', $card->getImageUrl());
-        $this->assertEquals('https://images.pokemontcg.io/xy7/54_hires.png', $card->getImageUrlHiRes());
-        $this->assertEquals('EX', $card->getSubtype());
         $this->assertEquals('Pokémon', $card->getSupertype());
+        $this->assertEquals(['Basic', 'EX'], $card->getSubtypes());
         $this->assertEquals('170', $card->getHp());
-        $this->assertEquals(['Colorless', 'Colorless', 'Colorless'], $card->getRetreatCost());
-        $this->assertEquals(['When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards.'], $card->getText());
-        $this->assertEquals('57', $card->getNumber());
-        $this->assertEquals('PLANETA', $card->getArtist());
-        $this->assertEquals('Rare Holo EX', $card->getRarity());
-        $this->assertEquals('XY', $card->getSeries());
-        $this->assertEquals('Ancient Origins', $card->getSet());
-        $this->assertEquals('xy7', $card->getSetCode());
         $this->assertEquals(['Dragon'], $card->getTypes());
+        $this->assertEquals(['Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards.'], $card->getRules());
 
-        $this->assertInstanceOf(Ability::class, $card->getAbility());
-        $this->assertEquals('Renegade Pulse', $card->getAbility()->getName());
-        $this->assertEquals('Prevent all effects of attacks, including damage, done to this Pokémon by your opponent\'s Mega Evolution Pokémon.', $card->getAbility()->getText());
-        $this->assertEquals('Ability', $card->getAbility()->getType());
+        $ability = $card->getAbilities()[0];
+        $this->assertInstanceOf(Ability::class, $ability);
+        $this->assertEquals('Renegade Pulse', $ability->getName());
+        $this->assertEquals('Prevent all effects of attacks, including damage, done to this Pokémon by your opponent\'s Mega Evolution Pokémon.', $ability->getText());
+        $this->assertEquals('Ability', $ability->getType());
 
-        /** @var Attack $attack */
         $attack = $card->getAttacks()[0];
         $this->assertInstanceOf(Attack::class, $attack);
-        $this->assertEquals(['Grass', 'Psychic', 'Colorless', 'Colorless'], $attack->getCost());
         $this->assertEquals('Chaos Wheel', $attack->getName());
-        $this->assertEquals('Your opponent can\'t play any Pokémon Tool, Special Energy, or Stadium cards from his or her hand during his or her next turn.', $attack->getText());
-        $this->assertEquals('100', $attack->getDamage());
+        $this->assertEquals(['Grass', 'Psychic', 'Colorless', 'Colorless'], $attack->getCost());
         $this->assertEquals(4, $attack->getConvertedEnergyCost());
+        $this->assertEquals('100', $attack->getDamage());
+        $this->assertEquals('Your opponent can\'t play any Pokémon Tool, Special Energy, or Stadium cards from his or her hand during his or her next turn.', $attack->getText());
 
-        /** @var Weakness $weakness */
         $weakness = $card->getWeaknesses()[0];
         $this->assertInstanceOf(Weakness::class, $weakness);
         $this->assertEquals('Fairy', $weakness->getType());
         $this->assertEquals('×2', $weakness->getValue());
+
+        $this->assertEquals(['Colorless', 'Colorless', 'Colorless'], $card->getRetreatCost());
+        $this->assertEquals(3, $card->getConvertedRetreatCost());
+
+        $set = $card->getSet();
+        $this->assertInstanceOf(Set::class, $set);
+        $this->assertEquals('xy7', $set->getId());
+        $this->assertEquals('Ancient Origins', $set->getName());
+        $this->assertEquals('XY', $set->getSeries());
+        $this->assertEquals(98, $set->getPrintedTotal());
+        $this->assertEquals(100, $set->getTotal());
+
+        $legalities = $set->getLegalities();
+        $this->assertInstanceOf(Legalities::class, $legalities);
+        $this->assertEquals('Legal', $legalities->getUnlimited());
+        $this->assertEquals('Legal', $legalities->getExpanded());
+
+        $this->assertEquals('AOR', $set->getPtcgoCode());
+        $this->assertEquals('2015/08/12', $set->getReleaseDate());
+
+        $images = $set->getImages();
+        $this->assertInstanceOf(SetImages::class, $images);
+        $this->assertEquals('https://images.pokemontcg.io/xy7/symbol.png', $images->getSymbol());
+        $this->assertEquals('https://images.pokemontcg.io/xy7/logo.png', $images->getLogo());
+
+        $this->assertEquals('57', $card->getNumber());
+        $this->assertEquals('PLANETA', $card->getArtist());
+        $this->assertEquals('Rare Holo EX', $card->getRarity());
+        $this->assertEquals([487], $card->getNationalPokedexNumbers());
+
+        $legalities = $card->getLegalities();
+        $this->assertInstanceOf(Legalities::class, $legalities);
+        $this->assertEquals('Legal', $legalities->getUnlimited());
+        $this->assertEquals('Legal', $legalities->getExpanded());
+
+        $images = $card->getImages();
+        $this->assertInstanceOf(CardImages::class, $images);
+        $this->assertEquals('https://images.pokemontcg.io/xy7/57.png', $images->getSmall());
+        $this->assertEquals('https://images.pokemontcg.io/xy7/57_hires.png', $images->getLarge());
+
+        $tcgplayer = $card->getTcgplayer();
+        $this->assertInstanceOf(TCGPlayer::class, $tcgplayer);
+        $this->assertEquals('https://prices.pokemontcg.io/tcgplayer/xy7-57', $tcgplayer->getUrl());
+
+        $prices = $tcgplayer->getPrices();
+        $this->assertInstanceOf(Prices::class, $prices);
+
+        $holofoil = $prices->getHolofoil();
+        $this->assertInstanceOf(PriceTiers::class, $holofoil);
+        $this->assertEquals(3.7, $holofoil->getLow());
+        $this->assertEquals(8.0, $holofoil->getMid());
+        $this->assertEquals(14.9, $holofoil->getHigh());
+        $this->assertEquals(6.0, $holofoil->getMarket());
+        $this->assertEquals(9.99, $holofoil->getDirectLow());
+
+        $this->assertEmpty($prices->getNormal());
+        $this->assertEmpty($prices->getReverseHolofoil());
+        $this->assertEmpty($prices->getFirstEditionNormal());
 
         $this->assertEmpty($card->getResistances());
         $this->assertEmpty($card->getAncientTrait());
     }
 
     /**
-     * Test page size and page
+     * Test page and page size
      */
-    public function testWhereWithPageSizeAndPageReturnsCards()
+    public function testPageAndPageSizeReturnsCards(): void
     {
-        $cards = Pokemon::Card($this->clientOptions)->where(['pageSize' => 10])->where(['page' => 1])->all();
+        Pokemon::Options($this->clientOptions);
+        $cards = Pokemon::Card()->page(1)->pageSize(10)->all();
         $this->assertEquals(10, count($cards));
         foreach ($cards as $card) {
             $this->assertInstanceOf(Card::class, $card);
@@ -109,18 +168,42 @@ class CardTest extends TestCase
     }
 
     /**
+     * Test pagination
+     */
+    public function testPagination(): void
+    {
+        /** @var Pagination $pagination */
+        Pokemon::Options($this->clientOptions);
+        $pagination = Pokemon::Card()->page(1)->pageSize(10)->pagination();
+
+        $this->assertInstanceOf(Pagination::class, $pagination);
+        $this->assertEquals(1, $pagination->getPage());
+        $this->assertEquals(10, $pagination->getPageSize());
+        $this->assertEquals(10, $pagination->getCount());
+        $this->assertEquals(13223, $pagination->getTotalCount());
+        $this->assertEquals(1323, $pagination->getTotalPages());
+    }
+
+    /**
      * Test find all cards with query
      */
-    public function testWhereFiltersOnCards()
+    public function testWhereFiltersOnCards(): void
     {
-        $cards = Pokemon::Card($this->clientOptions)->where(['supertype' => 'pokemon', 'subtype' => 'basic', 'set' => 'roaring skies'])->all();
+        Pokemon::Options($this->clientOptions);
+        $cards = Pokemon::Card()->where([
+            'supertype' => 'pokemon',
+            'subtypes' => 'basic',
+            'set.name' => 'roaring skies',
+            'types' => 'grass',
+        ])->all();
 
         /** @var Card $card */
         foreach ($cards as $card) {
             $this->assertInstanceOf(Card::class, $card);
             $this->assertEquals('Pokémon', $card->getSupertype());
-            $this->assertEquals('Basic', $card->getSubtype());
-            $this->assertEquals('Roaring Skies', $card->getSet());
+            $this->assertContains('Basic', $card->getSubtypes());
+            $this->assertEquals('Roaring Skies', $card->getSet()->getName());
+            $this->assertContains('Grass', $card->getTypes());
         }
     }
 }

--- a/tests/RarityTest.php
+++ b/tests/RarityTest.php
@@ -1,20 +1,22 @@
 <?php
 
+use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 use GuzzleHttp\Psr7\Response;
 use Pokemon\Pokemon;
 
 /**
- * Class SubtypeTest
+ * Class RarityTest
  */
-class SupertypeTest extends TestCase
+class RarityTest extends TestCase
 {
+    use ArraySubsetAsserts;
 
     /**
      * @return string
      */
     protected function fixtureDirectory(): string
     {
-        return 'supertypes';
+        return 'rarities';
     }
 
     /**
@@ -30,14 +32,14 @@ class SupertypeTest extends TestCase
     }
 
     /**
-     * Get all supertypes
+     * Get all types
      */
-    public function testAllReturnsAllSupertypes(): void
+    public function testAllReturnsAllTypes(): void
     {
         Pokemon::Options($this->clientOptions);
-        $supertypes = Pokemon::Supertype()->all();
+        $rarities = Pokemon::Rarity()->all();
 
-        $this->assertEquals(3, count($supertypes));
-        $this->assertEquals(['Energy', 'Pokémon', 'Trainer'], $supertypes);
+        $this->assertEquals(23, count($rarities));
+        $this->assertArraySubset(['Amazing Rare', 'Common', 'LEGEND', 'Promo'], $rarities);
     }
 }

--- a/tests/SetTest.php
+++ b/tests/SetTest.php
@@ -1,7 +1,10 @@
 <?php
 
 use GuzzleHttp\Psr7\Response;
+use Pokemon\Models\Legalities;
+use Pokemon\Models\Pagination;
 use Pokemon\Models\Set;
+use Pokemon\Models\SetImages;
 use Pokemon\Pokemon;
 
 /**
@@ -13,7 +16,7 @@ class SetTest extends TestCase
     /**
      * @return string
      */
-    protected function fixtureDirectory()
+    protected function fixtureDirectory(): string
     {
         return 'sets';
     }
@@ -29,6 +32,7 @@ class SetTest extends TestCase
             new Response(404),
             new Response(200, [], $this->getFixture('find.json')),
             new Response(200, [], $this->getFixture('page.json')),
+            new Response(200, [], $this->getFixture('page.json')),
             new Response(200, [], $this->getFixture('filtered.json')),
         ]);
     }
@@ -36,39 +40,50 @@ class SetTest extends TestCase
     /**
      * Test invalid set code
      */
-    public function testFindWithInvalidCodeThrowsException()
+    public function testFindWithInvalidCodeThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        Pokemon::Set($this->clientOptions)->find('invalid');
+        Pokemon::Options($this->clientOptions);
+        Pokemon::Set()->find('invalid');
     }
 
     /**
      * Test find set by code
      */
-    public function testFindReturnOneSet()
+    public function testFindReturnOneSet(): void
     {
         /** @var Set $set */
-        $set = Pokemon::Set($this->clientOptions)->find('g1');
+        Pokemon::Options($this->clientOptions);
+        $set = Pokemon::Set()->find('g1');
 
         $this->assertInstanceOf(Set::class, $set);
-        $this->assertEquals('g1', $set->getCode());
-        $this->assertEquals('GEN', $set->getPtcgoCode());
+        $this->assertEquals('g1', $set->getId());
         $this->assertEquals('Generations', $set->getName());
         $this->assertEquals('XY', $set->getSeries());
-        $this->assertEquals(115, $set->getTotalCards());
-        $this->assertEquals(true, $set->isStandardLegal());
-        $this->assertEquals(true, $set->isExpandedLegal());
-        $this->assertEquals('02/22/2016', $set->getReleaseDate());
-        $this->assertEquals('https://images.pokemontcg.io/g1/symbol.png', $set->getSymbolUrl());
-        $this->assertEquals('https://images.pokemontcg.io/g1/logo.png', $set->getLogoUrl());
+        $this->assertEquals(115, $set->getPrintedTotal());
+        $this->assertEquals(115, $set->getTotal());
+
+        $legalities = $set->getLegalities();
+        $this->assertInstanceOf(Legalities::class, $legalities);
+        $this->assertEquals('Legal', $legalities->getUnlimited());
+        $this->assertEquals('Legal', $legalities->getExpanded());
+
+        $this->assertEquals('GEN', $set->getPtcgoCode());
+        $this->assertEquals('2016/02/22', $set->getReleaseDate());
+
+        $images = $set->getImages();
+        $this->assertInstanceOf(SetImages::class, $images);
+        $this->assertEquals('https://images.pokemontcg.io/g1/symbol.png', $images->getSymbol());
+        $this->assertEquals('https://images.pokemontcg.io/g1/logo.png', $images->getLogo());
     }
 
     /**
-     * Test page size and page
+     * Test page and page size
      */
-    public function testWhereWithPageSizeAndPageReturnsSets()
+    public function testPageAndPageSizeReturnsSets(): void
     {
-        $sets = Pokemon::Set($this->clientOptions)->where(['pageSize' => 10])->where(['page' => 1])->all();
+        Pokemon::Options($this->clientOptions);
+        $sets = Pokemon::Set()->page(1)->pageSize(10)->all();
         $this->assertEquals(10, count($sets));
         foreach ($sets as $set) {
             $this->assertInstanceOf(Set::class, $set);
@@ -76,16 +91,34 @@ class SetTest extends TestCase
     }
 
     /**
+     * Test pagination
+     */
+    public function testPagination(): void
+    {
+        /** @var Pagination $pagination */
+        Pokemon::Options($this->clientOptions);
+        $pagination = Pokemon::Set()->page(1)->pageSize(10)->pagination();
+
+        $this->assertInstanceOf(Pagination::class, $pagination);
+        $this->assertEquals(1, $pagination->getPage());
+        $this->assertEquals(10, $pagination->getPageSize());
+        $this->assertEquals(10, $pagination->getCount());
+        $this->assertEquals(121, $pagination->getTotalCount());
+        $this->assertEquals(13, $pagination->getTotalPages());
+    }
+
+    /**
      * Test find all sets with query
      */
-    public function testWhereFiltersOnSets()
+    public function testWhereFiltersOnSets(): void
     {
-        $sets = Pokemon::Set($this->clientOptions)->where(['standardLegal' => "true"])->all();
+        Pokemon::Options($this->clientOptions);
+        $sets = Pokemon::Set()->where(['legalities.standard' => 'legal'])->all();
 
         /** @var Set $set */
         foreach ($sets as $set) {
             $this->assertInstanceOf(Set::class, $set);
-            $this->assertEquals(true, $set->isStandardLegal());
+            $this->assertEquals(true, $set->getLegalities()->getStandard() === 'Legal');
         }
     }
 

--- a/tests/SetTest.php
+++ b/tests/SetTest.php
@@ -21,7 +21,7 @@ class SetTest extends TestCase
     /**
      * Run before tests
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -38,7 +38,7 @@ class SetTest extends TestCase
      */
     public function testFindWithInvalidCodeThrowsException()
     {
-        $this->setExpectedException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         Pokemon::Set($this->clientOptions)->find('invalid');
     }
 

--- a/tests/SubtypeTest.php
+++ b/tests/SubtypeTest.php
@@ -14,7 +14,7 @@ class SubtypeTest extends TestCase
     /**
      * @return string
      */
-    protected function fixtureDirectory()
+    protected function fixtureDirectory(): string
     {
         return 'subtypes';
     }
@@ -34,11 +34,12 @@ class SubtypeTest extends TestCase
     /**
      * Get all subtypes
      */
-    public function testAllReturnsAllSubtypes()
+    public function testAllReturnsAllSubtypes(): void
     {
-        $subtypes = Pokemon::Subtype($this->clientOptions)->all();
+        Pokemon::Options($this->clientOptions);
+        $subtypes = Pokemon::Subtype()->all();
 
-        $this->assertEquals(17, count($subtypes));
-        $this->assertArraySubset(['MEGA', 'Item', 'Level Up', 'Supporter'], $subtypes);
+        $this->assertEquals(23, count($subtypes));
+        $this->assertArraySubset(['BREAK', 'Baby', 'Basic', 'EX', 'GX'], $subtypes);
     }
 }

--- a/tests/SubtypeTest.php
+++ b/tests/SubtypeTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 use GuzzleHttp\Psr7\Response;
 use Pokemon\Pokemon;
 
@@ -8,6 +9,7 @@ use Pokemon\Pokemon;
  */
 class SubtypeTest extends TestCase
 {
+    use ArraySubsetAsserts;
 
     /**
      * @return string
@@ -20,7 +22,7 @@ class SubtypeTest extends TestCase
     /**
      * Run before tests
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/SupertypeTest.php
+++ b/tests/SupertypeTest.php
@@ -20,7 +20,7 @@ class SupertypeTest extends TestCase
     /**
      * Run before tests
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TypeTest.php
+++ b/tests/TypeTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 use GuzzleHttp\Psr7\Response;
 use Pokemon\Pokemon;
 
@@ -8,6 +9,7 @@ use Pokemon\Pokemon;
  */
 class TypeTest extends TestCase
 {
+    use ArraySubsetAsserts;
 
     /**
      * @return string
@@ -20,7 +22,7 @@ class TypeTest extends TestCase
     /**
      * Run before tests
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TypeTest.php
+++ b/tests/TypeTest.php
@@ -5,7 +5,7 @@ use GuzzleHttp\Psr7\Response;
 use Pokemon\Pokemon;
 
 /**
- * Class TypesTest
+ * Class TypeTest
  */
 class TypeTest extends TestCase
 {
@@ -14,7 +14,7 @@ class TypeTest extends TestCase
     /**
      * @return string
      */
-    protected function fixtureDirectory()
+    protected function fixtureDirectory(): string
     {
         return 'types';
     }
@@ -34,11 +34,12 @@ class TypeTest extends TestCase
     /**
      * Get all types
      */
-    public function testAllReturnsAllTypes()
+    public function testAllReturnsAllTypes(): void
     {
-        $types = Pokemon::Type($this->clientOptions)->all();
+        Pokemon::Options($this->clientOptions);
+        $types = Pokemon::Type()->all();
 
-        $this->assertEquals(12, count($types));
-        $this->assertArraySubset(['Colorless', 'Dark'], $types);
+        $this->assertEquals(11, count($types));
+        $this->assertArraySubset(['Colorless', 'Darkness', 'Dragon', 'Fairy'], $types);
     }
 }

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -28,28 +28,28 @@ abstract class TestCase extends PHPUnitTestCase
         $this->clientOptions = array_merge($this->clientOptions, ['verify' => getenv('CLIENT_OPTION_VERIFY')]);
     }
 
-	/**
-	 * @return string
-	 */
-    abstract protected function fixtureDirectory();
+    /**
+     * @return string
+     */
+    abstract protected function fixtureDirectory(): string;
 
-	/**
-	 * @param $file
-	 *
-	 * @return string
-	 */
-	protected function getFixture($file)
-	{
-		$path = __DIR__ . '/fixtures/' . $this->fixtureDirectory() . '/';
-		return file_get_contents($path . $file);
-	}
+    /**
+     * @param $file
+     *
+     * @return string
+     */
+    protected function getFixture($file): string
+    {
+        $path = __DIR__ . '/fixtures/' . $this->fixtureDirectory() . '/';
+        return file_get_contents($path . $file);
+    }
 
     /**
      * Call this in setUp() to mock api responses in test cases.
      *
      * @param array $responses
      */
-    protected function setUpClientResponses(array $responses = [])
+    protected function setUpClientResponses(array $responses = []): void
     {
         $mock = new MockHandler($responses);
         $handler = HandlerStack::create($mock);

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -2,11 +2,12 @@
 
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
+use PHPUnit\Framework\TestCase as PHPUnitTestCase;
 
 /**
  * Class TestCase
  */
-abstract class TestCase extends PHPUnit_Framework_TestCase
+abstract class TestCase extends PHPUnitTestCase
 {
     /**
      * @var array
@@ -21,7 +22,7 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
     /**
      * Run before tests
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->clientOptions = array_merge($this->clientOptions, ['verify' => getenv('CLIENT_OPTION_VERIFY')]);

--- a/tests/lib/fixtures/cards/filtered.json
+++ b/tests/lib/fixtures/cards/filtered.json
@@ -1,1876 +1,396 @@
 {
-    "cards": [
+  "data": [
+    {
+      "id": "xy6-1",
+      "name": "Exeggcute",
+      "supertype": "Pokémon",
+      "subtypes": [
+        "Basic"
+      ],
+      "hp": "40",
+      "types": [
+        "Grass"
+      ],
+      "evolvesTo": [
+        "Exeggutor"
+      ],
+      "attacks": [
         {
-            "id": "xy6-27",
-            "name": "Natu",
-            "nationalPokedexNumber": 177,
-            "imageUrl": "https://images.pokemontcg.io/xy6/27.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy6/27_hires.png",
-            "subtype": "Basic",
-            "supertype": "Pokémon",
-            "hp": "50",
-            "retreatCost": [
-                "Colorless"
-            ],
-            "number": "27",
-            "artist": "Atsuko Nishida",
-            "rarity": "Common",
-            "series": "XY",
-            "set": "Roaring Skies",
-            "setCode": "xy6",
-            "types": [
-                "Psychic"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Colorless"
-                    ],
-                    "name": "Peck",
-                    "text": "",
-                    "damage": "10",
-                    "convertedEnergyCost": 1
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Psychic",
-                    "value": "×2"
-                }
-            ]
+          "name": "Loathe",
+          "cost": [
+            "Colorless"
+          ],
+          "convertedEnergyCost": 1,
+          "damage": "",
+          "text": "Flip a coin. If heads, switch this Pokémon with 1 of your Benched Pokémon."
         },
         {
-            "id": "xy6-1",
-            "name": "Exeggcute",
-            "nationalPokedexNumber": 102,
-            "imageUrl": "https://images.pokemontcg.io/xy6/1.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy6/1_hires.png",
-            "subtype": "Basic",
-            "supertype": "Pokémon",
-            "hp": "40",
-            "retreatCost": [
-                "Colorless"
-            ],
-            "number": "1",
-            "artist": "Tomokazu Komiya",
-            "rarity": "Common",
-            "series": "XY",
-            "set": "Roaring Skies",
-            "setCode": "xy6",
-            "types": [
-                "Grass"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Colorless"
-                    ],
-                    "name": "Loathe",
-                    "text": "Flip a coin. If heads, switch this Pokémon with 1 of your Benched Pokémon.",
-                    "damage": "",
-                    "convertedEnergyCost": 1
-                },
-                {
-                    "cost": [
-                        "Grass"
-                    ],
-                    "name": "Ram",
-                    "text": "",
-                    "damage": "10",
-                    "convertedEnergyCost": 1
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Fire",
-                    "value": "×2"
-                }
-            ]
-        },
-        {
-            "id": "xy6-3",
-            "name": "Wurmple",
-            "nationalPokedexNumber": 265,
-            "imageUrl": "https://images.pokemontcg.io/xy6/3.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy6/3_hires.png",
-            "subtype": "Basic",
-            "supertype": "Pokémon",
-            "hp": "60",
-            "retreatCost": [
-                "Colorless"
-            ],
-            "number": "3",
-            "artist": "Naoyo Kimura",
-            "rarity": "Common",
-            "series": "XY",
-            "set": "Roaring Skies",
-            "setCode": "xy6",
-            "types": [
-                "Grass"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Grass"
-                    ],
-                    "name": "Flock",
-                    "text": "Search your deck for Wurmple and put it onto your Bench. Shuffle your deck afterward.",
-                    "damage": "",
-                    "convertedEnergyCost": 1
-                },
-                {
-                    "cost": [
-                        "Colorless",
-                        "Colorless"
-                    ],
-                    "name": "Tackle",
-                    "text": "",
-                    "damage": "20",
-                    "convertedEnergyCost": 2
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Fire",
-                    "value": "×2"
-                }
-            ]
-        },
-        {
-            "id": "xy6-9",
-            "name": "Nincada",
-            "nationalPokedexNumber": 290,
-            "imageUrl": "https://images.pokemontcg.io/xy6/9.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy6/9_highres.png",
-            "subtype": "Basic",
-            "supertype": "Pokémon",
-            "hp": "40",
-            "retreatCost": [
-                "Colorless"
-            ],
-            "number": "9",
-            "artist": "Kyoko Umemoto",
-            "rarity": "Common",
-            "series": "XY",
-            "set": "Roaring Skies",
-            "setCode": "xy6",
-            "types": [
-                "Grass"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Colorless"
-                    ],
-                    "name": "Slight Intrusion",
-                    "text": "This Pokémon does 10 damage to itself.",
-                    "damage": "20",
-                    "convertedEnergyCost": 1
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Fire",
-                    "value": "×2"
-                }
-            ]
-        },
-        {
-            "id": "xy6-28",
-            "name": "Natu",
-            "nationalPokedexNumber": 177,
-            "imageUrl": "https://images.pokemontcg.io/xy6/28.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy6/28_hires.png",
-            "subtype": "Basic",
-            "supertype": "Pokémon",
-            "ancientTrait": {
-                "name": "Δ Plus",
-                "text": "If your opponent's Pokémon is Knocked Out by damage from an attack of this Pokémon, take 1 more Prize card."
-            },
-            "hp": "40",
-            "retreatCost": [
-                "Colorless"
-            ],
-            "number": "28",
-            "artist": "Kagemaru Himeno",
-            "rarity": "Common",
-            "series": "XY",
-            "set": "Roaring Skies",
-            "setCode": "xy6",
-            "types": [
-                "Psychic"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Psychic",
-                        "Colorless"
-                    ],
-                    "name": "Psywave",
-                    "text": "This attack does 10 damage times the amount of Energy attached to your opponent's Active Pokémon.",
-                    "damage": "10×",
-                    "convertedEnergyCost": 2
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Psychic",
-                    "value": "×2"
-                }
-            ]
-        },
-        {
-            "id": "xy6-12",
-            "name": "Tropius",
-            "nationalPokedexNumber": 357,
-            "imageUrl": "https://images.pokemontcg.io/xy6/12.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy6/12_hires.png",
-            "subtype": "Basic",
-            "supertype": "Pokémon",
-            "hp": "110",
-            "retreatCost": [
-                "Colorless",
-                "Colorless"
-            ],
-            "number": "12",
-            "artist": "Kyoko Umemoto",
-            "rarity": "Uncommon",
-            "series": "XY",
-            "set": "Roaring Skies",
-            "setCode": "xy6",
-            "types": [
-                "Grass"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Colorless",
-                        "Colorless",
-                        "Colorless"
-                    ],
-                    "name": "Stomp",
-                    "text": "Flip a coin. If heads, this attack does 20 more damage.",
-                    "damage": "50+",
-                    "convertedEnergyCost": 3
-                },
-                {
-                    "cost": [
-                        "Grass",
-                        "Colorless",
-                        "Colorless",
-                        "Colorless"
-                    ],
-                    "name": "Solar Beam",
-                    "text": "",
-                    "damage": "80",
-                    "convertedEnergyCost": 4
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Fire",
-                    "value": "×2"
-                }
-            ]
-        },
-        {
-            "id": "xy6-13",
-            "name": "Victini",
-            "nationalPokedexNumber": 494,
-            "imageUrl": "https://images.pokemontcg.io/xy6/13.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy6/13_hires.png",
-            "subtype": "Basic",
-            "supertype": "Pokémon",
-            "hp": "70",
-            "retreatCost": [
-                "Colorless"
-            ],
-            "number": "13",
-            "artist": "Kouki Saitou",
-            "rarity": "Rare",
-            "series": "XY",
-            "set": "Roaring Skies",
-            "setCode": "xy6",
-            "types": [
-                "Fire"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Colorless"
-                    ],
-                    "name": "Me First",
-                    "text": "Draw a card.",
-                    "damage": "",
-                    "convertedEnergyCost": 1
-                },
-                {
-                    "cost": [
-                        "Fire",
-                        "Colorless"
-                    ],
-                    "name": "Psy Bolt",
-                    "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.",
-                    "damage": "20",
-                    "convertedEnergyCost": 2
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Water",
-                    "value": "×2"
-                }
-            ]
-        },
-        {
-            "id": "xy6-16",
-            "name": "Articuno",
-            "nationalPokedexNumber": 144,
-            "imageUrl": "https://images.pokemontcg.io/xy6/16.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy6/16_hires.png",
-            "subtype": "Basic",
-            "supertype": "Pokémon",
-            "hp": "120",
-            "retreatCost": [
-                "Colorless"
-            ],
-            "number": "16",
-            "artist": "Naoki Saito",
-            "rarity": "Rare",
-            "series": "XY",
-            "set": "Roaring Skies",
-            "setCode": "xy6",
-            "types": [
-                "Water"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Water"
-                    ],
-                    "name": "Find Ice",
-                    "text": "Search your deck for up to 3 Water Energy cards, reveal them, and put them into your hand. Shuffle your deck afterward.",
-                    "damage": "",
-                    "convertedEnergyCost": 1
-                },
-                {
-                    "cost": [
-                        "Water",
-                        "Water",
-                        "Colorless",
-                        "Colorless"
-                    ],
-                    "name": "Freezing Wind",
-                    "text": "",
-                    "damage": "100",
-                    "convertedEnergyCost": 4
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Metal",
-                    "value": "×2"
-                }
-            ],
-            "resistances": [
-                {
-                    "type": "Fighting",
-                    "value": "-20"
-                }
-            ]
-        },
-        {
-            "id": "xy6-17",
-            "name": "Articuno",
-            "nationalPokedexNumber": 144,
-            "imageUrl": "https://images.pokemontcg.io/xy6/17.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy6/17_hires.png",
-            "subtype": "Basic",
-            "supertype": "Pokémon",
-            "ancientTrait": {
-                "name": "Δ Plus",
-                "text": "If your opponent's Pokémon is Knocked Out by damage from an attack of this Pokémon, take 1 more Prize card."
-            },
-            "hp": "120",
-            "retreatCost": [
-                "Colorless",
-                "Colorless"
-            ],
-            "number": "17",
-            "artist": "5ban Graphics",
-            "rarity": "Rare",
-            "series": "XY",
-            "set": "Roaring Skies",
-            "setCode": "xy6",
-            "types": [
-                "Water"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Water"
-                    ],
-                    "name": "Chilling Sigh",
-                    "text": "Your opponent's Active Pokémon is now Asleep.",
-                    "damage": "",
-                    "convertedEnergyCost": 1
-                },
-                {
-                    "cost": [
-                        "Water",
-                        "Water",
-                        "Colorless"
-                    ],
-                    "name": "Tri Edge",
-                    "text": "Flip 3 coins. This attack does 40 more damage for each heads.",
-                    "damage": "20+",
-                    "convertedEnergyCost": 3
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Metal",
-                    "value": "×2"
-                }
-            ],
-            "resistances": [
-                {
-                    "type": "Fighting",
-                    "value": "-20"
-                }
-            ]
-        },
-        {
-            "id": "xy6-18",
-            "name": "Wingull",
-            "nationalPokedexNumber": 278,
-            "imageUrl": "https://images.pokemontcg.io/xy6/18.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy6/18_hires.png",
-            "subtype": "Basic",
-            "supertype": "Pokémon",
-            "hp": "60",
-            "retreatCost": [
-                "Colorless"
-            ],
-            "number": "18",
-            "artist": "MAHOU",
-            "rarity": "Common",
-            "series": "XY",
-            "set": "Roaring Skies",
-            "setCode": "xy6",
-            "types": [
-                "Water"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Water"
-                    ],
-                    "name": "Water Gun",
-                    "text": "",
-                    "damage": "10",
-                    "convertedEnergyCost": 1
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Lightning",
-                    "value": "×2"
-                }
-            ],
-            "resistances": [
-                {
-                    "type": "Fighting",
-                    "value": "-20"
-                }
-            ]
-        },
-        {
-            "id": "xy6-20",
-            "name": "Pikachu",
-            "nationalPokedexNumber": 25,
-            "imageUrl": "https://images.pokemontcg.io/xy6/20.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy6/20_hires.png",
-            "subtype": "Basic",
-            "supertype": "Pokémon",
-            "hp": "60",
-            "retreatCost": [
-                "Colorless"
-            ],
-            "number": "20",
-            "artist": "Naoki Saito",
-            "rarity": "Common",
-            "series": "XY",
-            "set": "Roaring Skies",
-            "setCode": "xy6",
-            "types": [
-                "Lightning"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Colorless"
-                    ],
-                    "name": "Tail Whip",
-                    "text": "Flip a coin. If heads, the Defending Pokémon can't attack during your opponent's next turn.",
-                    "damage": "",
-                    "convertedEnergyCost": 1
-                },
-                {
-                    "cost": [
-                        "Lightning",
-                        "Colorless"
-                    ],
-                    "name": "Electro Ball",
-                    "text": "",
-                    "damage": "30",
-                    "convertedEnergyCost": 2
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Fighting",
-                    "value": "×2"
-                }
-            ],
-            "resistances": [
-                {
-                    "type": "Metal",
-                    "value": "-20"
-                }
-            ]
-        },
-        {
-            "id": "xy6-21",
-            "name": "Voltorb",
-            "nationalPokedexNumber": 100,
-            "imageUrl": "https://images.pokemontcg.io/xy6/21.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy6/21_hires.png",
-            "subtype": "Basic",
-            "supertype": "Pokémon",
-            "hp": "60",
-            "retreatCost": [
-                "Colorless"
-            ],
-            "number": "21",
-            "artist": "Suwama Chiaki",
-            "rarity": "Common",
-            "series": "XY",
-            "set": "Roaring Skies",
-            "setCode": "xy6",
-            "types": [
-                "Lightning"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Lightning"
-                    ],
-                    "name": "Thunder Wave",
-                    "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.",
-                    "damage": "",
-                    "convertedEnergyCost": 1
-                },
-                {
-                    "cost": [
-                        "Lightning",
-                        "Colorless"
-                    ],
-                    "name": "Big Explosion",
-                    "text": "This Pokémon does 60 damage to itself.",
-                    "damage": "60",
-                    "convertedEnergyCost": 2
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Fighting",
-                    "value": "×2"
-                }
-            ],
-            "resistances": [
-                {
-                    "type": "Metal",
-                    "value": "-20"
-                }
-            ]
-        },
-        {
-            "id": "xy6-23",
-            "name": "Zapdos",
-            "nationalPokedexNumber": 145,
-            "imageUrl": "https://images.pokemontcg.io/xy6/23.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy6/23_hires.png",
-            "subtype": "Basic",
-            "supertype": "Pokémon",
-            "hp": "120",
-            "retreatCost": [
-                "Colorless",
-                "Colorless"
-            ],
-            "number": "23",
-            "artist": "Hitoshi Ariga",
-            "rarity": "Rare",
-            "series": "XY",
-            "set": "Roaring Skies",
-            "setCode": "xy6",
-            "types": [
-                "Lightning"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Lightning"
-                    ],
-                    "name": "Drill Peck",
-                    "text": "",
-                    "damage": "20",
-                    "convertedEnergyCost": 1
-                },
-                {
-                    "cost": [
-                        "Lightning",
-                        "Lightning",
-                        "Colorless"
-                    ],
-                    "name": "Raging Thunder",
-                    "text": "This attack does 40 damage to 1 of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
-                    "damage": "120",
-                    "convertedEnergyCost": 3
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Lightning",
-                    "value": "×2"
-                }
-            ],
-            "resistances": [
-                {
-                    "type": "Fighting",
-                    "value": "-20"
-                }
-            ]
-        },
-        {
-            "id": "xy6-24",
-            "name": "Electrike",
-            "nationalPokedexNumber": 309,
-            "imageUrl": "https://images.pokemontcg.io/xy6/24.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy6/24_hires.png",
-            "subtype": "Basic",
-            "supertype": "Pokémon",
-            "hp": "60",
-            "retreatCost": [
-                "Colorless"
-            ],
-            "number": "24",
-            "artist": "Akira Komayama",
-            "rarity": "Common",
-            "series": "XY",
-            "set": "Roaring Skies",
-            "setCode": "xy6",
-            "types": [
-                "Lightning"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Colorless"
-                    ],
-                    "name": "Bite",
-                    "text": "",
-                    "damage": "10",
-                    "convertedEnergyCost": 1
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Fighting",
-                    "value": "×2"
-                }
-            ],
-            "resistances": [
-                {
-                    "type": "Metal",
-                    "value": "-20"
-                }
-            ]
-        },
-        {
-            "id": "xy6-30",
-            "name": "Shuppet",
-            "nationalPokedexNumber": 353,
-            "imageUrl": "https://images.pokemontcg.io/xy6/30.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy6/30_hires.png",
-            "subtype": "Basic",
-            "supertype": "Pokémon",
-            "hp": "60",
-            "retreatCost": [
-                "Colorless"
-            ],
-            "number": "30",
-            "artist": "Yukiko Baba",
-            "rarity": "Common",
-            "series": "XY",
-            "set": "Roaring Skies",
-            "setCode": "xy6",
-            "types": [
-                "Psychic"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Psychic"
-                    ],
-                    "name": "Bleh",
-                    "text": "Discard a Special Energy attached to 1 of your opponent's Pokémon.",
-                    "damage": "",
-                    "convertedEnergyCost": 1
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Darkness",
-                    "value": "×2"
-                }
-            ],
-            "resistances": [
-                {
-                    "type": "Fighting",
-                    "value": "-20"
-                }
-            ]
-        },
-        {
-            "id": "xy6-33",
-            "name": "Deoxys",
-            "nationalPokedexNumber": 386,
-            "imageUrl": "https://images.pokemontcg.io/xy6/33.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy6/33_hires.png",
-            "subtype": "Basic",
-            "supertype": "Pokémon",
-            "hp": "110",
-            "retreatCost": [
-                "Colorless"
-            ],
-            "number": "33",
-            "artist": "kawayoo",
-            "rarity": "Rare Holo",
-            "series": "XY",
-            "set": "Roaring Skies",
-            "setCode": "xy6",
-            "types": [
-                "Psychic"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Colorless"
-                    ],
-                    "name": "Close Encounter",
-                    "text": "If you go first, you can use this attack on your first turn. Draw 2 cards.",
-                    "damage": "",
-                    "convertedEnergyCost": 1
-                },
-                {
-                    "cost": [
-                        "Psychic",
-                        "Colorless"
-                    ],
-                    "name": "Overdrive Smash",
-                    "text": "During your next turn, this Pokémon's Overdrive Smash attack does 60 more damage (before applying Weakness and Resistance).",
-                    "damage": "30",
-                    "convertedEnergyCost": 2
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Psychic",
-                    "value": "×2"
-                }
-            ]
-        },
-        {
-            "id": "xy6-36",
-            "name": "Gligar",
-            "nationalPokedexNumber": 207,
-            "imageUrl": "https://images.pokemontcg.io/xy6/36.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy6/36_hires.png",
-            "subtype": "Basic",
-            "supertype": "Pokémon",
-            "hp": "70",
-            "retreatCost": [
-                "Colorless"
-            ],
-            "number": "36",
-            "artist": "Suwama Chiaki",
-            "rarity": "Common",
-            "series": "XY",
-            "set": "Roaring Skies",
-            "setCode": "xy6",
-            "types": [
-                "Fighting"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Colorless"
-                    ],
-                    "name": "Stun Poison",
-                    "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed and Poisoned.",
-                    "damage": "",
-                    "convertedEnergyCost": 1
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Water",
-                    "value": "×2"
-                }
-            ]
-        },
-        {
-            "id": "xy6-38",
-            "name": "Binacle",
-            "nationalPokedexNumber": 688,
-            "imageUrl": "https://images.pokemontcg.io/xy6/38.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy6/38_hires.png",
-            "subtype": "Basic",
-            "supertype": "Pokémon",
-            "hp": "60",
-            "retreatCost": [
-                "Colorless",
-                "Colorless"
-            ],
-            "number": "38",
-            "artist": "Kanako Eo",
-            "rarity": "Common",
-            "series": "XY",
-            "set": "Roaring Skies",
-            "setCode": "xy6",
-            "types": [
-                "Fighting"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Fighting"
-                    ],
-                    "name": "Sand Attack",
-                    "text": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing.",
-                    "damage": "",
-                    "convertedEnergyCost": 1
-                },
-                {
-                    "cost": [
-                        "Fighting",
-                        "Fighting",
-                        "Colorless"
-                    ],
-                    "name": "Mud-Slap",
-                    "text": "",
-                    "damage": "40",
-                    "convertedEnergyCost": 3
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Grass",
-                    "value": "×2"
-                }
-            ]
-        },
-        {
-            "id": "xy6-39",
-            "name": "Hawlucha",
-            "nationalPokedexNumber": 701,
-            "imageUrl": "https://images.pokemontcg.io/xy6/39.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy6/39_hires.png",
-            "subtype": "Basic",
-            "supertype": "Pokémon",
-            "hp": "80",
-            "retreatCost": [
-                "Colorless"
-            ],
-            "number": "39",
-            "artist": "Shin Nagasawa",
-            "rarity": "Common",
-            "series": "XY",
-            "set": "Roaring Skies",
-            "setCode": "xy6",
-            "types": [
-                "Fighting"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Fighting"
-                    ],
-                    "name": "Tackle",
-                    "text": "",
-                    "damage": "10",
-                    "convertedEnergyCost": 1
-                },
-                {
-                    "cost": [
-                        "Colorless",
-                        "Colorless",
-                        "Colorless"
-                    ],
-                    "name": "Midair Strike",
-                    "text": "Flip a coin. If heads, this attack does 40 more damage.",
-                    "damage": "40+",
-                    "convertedEnergyCost": 3
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Lightning",
-                    "value": "×2"
-                }
-            ],
-            "resistances": [
-                {
-                    "type": "Fighting",
-                    "value": "-20"
-                }
-            ]
-        },
-        {
-            "id": "xy6-40",
-            "name": "Absol",
-            "nationalPokedexNumber": 359,
-            "imageUrl": "https://images.pokemontcg.io/xy6/40.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy6/40_hires.png",
-            "subtype": "Basic",
-            "supertype": "Pokémon",
-            "ability": {
-                "name": "Cursed Eyes",
-                "text": "When you play this Pokémon from your hand onto your Bench, you may move 3 damage counters from 1 of your opponent's Pokémon to another of his or her Pokémon."
-            },
-            "hp": "100",
-            "retreatCost": [
-                "Colorless"
-            ],
-            "number": "40",
-            "artist": "Kagemaru Himeno",
-            "rarity": "Rare Holo",
-            "series": "XY",
-            "set": "Roaring Skies",
-            "setCode": "xy6",
-            "types": [
-                "Darkness"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Darkness",
-                        "Colorless"
-                    ],
-                    "name": "Mach Claw",
-                    "text": "This attack's damage isn't affected by Resistance.",
-                    "damage": "30",
-                    "convertedEnergyCost": 2
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Fighting",
-                    "value": "×2"
-                }
-            ],
-            "resistances": [
-                {
-                    "type": "Psychic",
-                    "value": "-20"
-                }
-            ]
-        },
-        {
-            "id": "xy6-41",
-            "name": "Inkay",
-            "nationalPokedexNumber": 686,
-            "imageUrl": "https://images.pokemontcg.io/xy6/41.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy6/41_hires.png",
-            "subtype": "Basic",
-            "supertype": "Pokémon",
-            "hp": "50",
-            "retreatCost": [
-                "Colorless"
-            ],
-            "number": "41",
-            "artist": "Akira Komayama",
-            "rarity": "Common",
-            "series": "XY",
-            "set": "Roaring Skies",
-            "setCode": "xy6",
-            "types": [
-                "Darkness"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Darkness"
-                    ],
-                    "name": "Rip Off",
-                    "text": "Choose a random card from your opponent's hand. Your opponent reveals that card and shuffles it into his or her deck.",
-                    "damage": "",
-                    "convertedEnergyCost": 1
-                },
-                {
-                    "cost": [
-                        "Darkness",
-                        "Colorless"
-                    ],
-                    "name": "Psybeam",
-                    "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Confused.",
-                    "damage": "20",
-                    "convertedEnergyCost": 2
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Fighting",
-                    "value": "×2"
-                }
-            ],
-            "resistances": [
-                {
-                    "type": "Psychic",
-                    "value": "-20"
-                }
-            ]
-        },
-        {
-            "id": "xy6-42",
-            "name": "Jirachi",
-            "nationalPokedexNumber": 385,
-            "imageUrl": "https://images.pokemontcg.io/xy6/42.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy6/42_hires.png",
-            "subtype": "Basic",
-            "supertype": "Pokémon",
-            "hp": "70",
-            "retreatCost": [
-                "Colorless"
-            ],
-            "number": "42",
-            "artist": "Sanosuke Sakuma",
-            "rarity": "Rare Holo",
-            "series": "XY",
-            "set": "Roaring Skies",
-            "setCode": "xy6",
-            "types": [
-                "Metal"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Metal"
-                    ],
-                    "name": "Diminutive Desire",
-                    "text": "Look at the top 7 cards of your deck and put 1 of them into your hand. Shuffle the other cards back into your deck.",
-                    "damage": "",
-                    "convertedEnergyCost": 1
-                },
-                {
-                    "cost": [
-                        "Metal",
-                        "Colorless"
-                    ],
-                    "name": "Doom Desire",
-                    "text": "Discard all Energy attached to this Pokémon. The Defending Pokémon is Knocked Out at the end of your opponent's next turn.",
-                    "damage": "",
-                    "convertedEnergyCost": 2
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Fire",
-                    "value": "×2"
-                }
-            ],
-            "resistances": [
-                {
-                    "type": "Psychic",
-                    "value": "-20"
-                }
-            ]
-        },
-        {
-            "id": "xy6-43",
-            "name": "Togepi",
-            "nationalPokedexNumber": 175,
-            "imageUrl": "https://images.pokemontcg.io/xy6/43.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy6/43_hires.png",
-            "subtype": "Basic",
-            "supertype": "Pokémon",
-            "hp": "40",
-            "retreatCost": [
-                "Colorless"
-            ],
-            "number": "43",
-            "artist": "HiRON",
-            "rarity": "Common",
-            "series": "XY",
-            "set": "Roaring Skies",
-            "setCode": "xy6",
-            "types": [
-                "Fairy"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Colorless"
-                    ],
-                    "name": "Sweet Kiss",
-                    "text": "Your opponent draws a card.",
-                    "damage": "10",
-                    "convertedEnergyCost": 1
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Metal",
-                    "value": "×2"
-                }
-            ],
-            "resistances": [
-                {
-                    "type": "Darkness",
-                    "value": "-20"
-                }
-            ]
-        },
-        {
-            "id": "xy6-47",
-            "name": "Carbink",
-            "nationalPokedexNumber": 703,
-            "imageUrl": "https://images.pokemontcg.io/xy6/47.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy6/47_hires.png",
-            "subtype": "Basic",
-            "supertype": "Pokémon",
-            "ability": {
-                "name": "Jewel Armor",
-                "text": "As long as this Pokémon is on your Bench, prevent all damage done to this Pokémon by attacks (both yours and your opponent's)."
-            },
-            "hp": "70",
-            "retreatCost": [
-                "Colorless",
-                "Colorless"
-            ],
-            "number": "47",
-            "artist": "Akira Komayama",
-            "rarity": "Rare",
-            "series": "XY",
-            "set": "Roaring Skies",
-            "setCode": "xy6",
-            "types": [
-                "Fairy"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Fairy",
-                        "Colorless",
-                        "Colorless"
-                    ],
-                    "name": "Spin Tackle",
-                    "text": "Flip a coin. If tails, this Pokémon does 20 damage to itself.",
-                    "damage": "60",
-                    "convertedEnergyCost": 3
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Metal",
-                    "value": "×2"
-                }
-            ],
-            "resistances": [
-                {
-                    "type": "Darkness",
-                    "value": "-20"
-                }
-            ]
-        },
-        {
-            "id": "xy6-48",
-            "name": "Klefki",
-            "nationalPokedexNumber": 707,
-            "imageUrl": "https://images.pokemontcg.io/xy6/48.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy6/48_hires.png",
-            "subtype": "Basic",
-            "supertype": "Pokémon",
-            "hp": "60",
-            "retreatCost": [
-                "Colorless"
-            ],
-            "number": "48",
-            "artist": "Kagemaru Himeno",
-            "rarity": "Rare",
-            "series": "XY",
-            "set": "Roaring Skies",
-            "setCode": "xy6",
-            "types": [
-                "Fairy"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Fairy"
-                    ],
-                    "name": "Look for Keys",
-                    "text": "Reveal cards from the top of your deck until you reveal an Item card. Put it into your hand. Shuffle the other cards back into your deck.",
-                    "damage": "",
-                    "convertedEnergyCost": 1
-                },
-                {
-                    "cost": [
-                        "Fairy",
-                        "Colorless"
-                    ],
-                    "name": "Play Rough",
-                    "text": "Flip a coin. If heads, this attack does 20 more damage.",
-                    "damage": "20+",
-                    "convertedEnergyCost": 2
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Metal",
-                    "value": "×2"
-                }
-            ],
-            "resistances": [
-                {
-                    "type": "Darkness",
-                    "value": "-20"
-                }
-            ]
-        },
-        {
-            "id": "xy6-49",
-            "name": "Dratini",
-            "nationalPokedexNumber": 147,
-            "imageUrl": "https://images.pokemontcg.io/xy6/49.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy6/49_hires.png",
-            "subtype": "Basic",
-            "supertype": "Pokémon",
-            "hp": "50",
-            "retreatCost": [
-                "Colorless"
-            ],
-            "number": "49",
-            "artist": "Miki Tanaka",
-            "rarity": "Common",
-            "series": "XY",
-            "set": "Roaring Skies",
-            "setCode": "xy6",
-            "types": [
-                "Dragon"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Grass"
-                    ],
-                    "name": "Hook",
-                    "text": "",
-                    "damage": "10",
-                    "convertedEnergyCost": 1
-                },
-                {
-                    "cost": [
-                        "Lightning",
-                        "Colorless"
-                    ],
-                    "name": "Slam",
-                    "text": "Flip 2 coins. This attack does 20 damage times the number of heads.",
-                    "damage": "20×",
-                    "convertedEnergyCost": 2
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Fairy",
-                    "value": "×2"
-                }
-            ]
-        },
-        {
-            "id": "xy6-68",
-            "name": "Dunsparce",
-            "nationalPokedexNumber": 206,
-            "imageUrl": "https://images.pokemontcg.io/xy6/68.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy6/68_hires.png",
-            "subtype": "Basic",
-            "supertype": "Pokémon",
-            "hp": "60",
-            "number": "68",
-            "artist": "Yuka Morii",
-            "rarity": "Common",
-            "series": "XY",
-            "set": "Roaring Skies",
-            "setCode": "xy6",
-            "types": [
-                "Colorless"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Colorless"
-                    ],
-                    "name": "Burrow",
-                    "text": "Discard the top card of your opponent's deck.",
-                    "damage": "",
-                    "convertedEnergyCost": 1
-                },
-                {
-                    "cost": [
-                        "Colorless"
-                    ],
-                    "name": "Rollout",
-                    "text": "",
-                    "damage": "20",
-                    "convertedEnergyCost": 1
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Fighting",
-                    "value": "×2"
-                }
-            ]
-        },
-        {
-            "id": "xy6-54",
-            "name": "Bagon",
-            "nationalPokedexNumber": 371,
-            "imageUrl": "https://images.pokemontcg.io/xy6/54.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy6/54_hires.png",
-            "subtype": "Basic",
-            "supertype": "Pokémon",
-            "hp": "60",
-            "retreatCost": [
-                "Colorless"
-            ],
-            "number": "54",
-            "artist": "Kagemaru Himeno",
-            "rarity": "Common",
-            "series": "XY",
-            "set": "Roaring Skies",
-            "setCode": "xy6",
-            "types": [
-                "Dragon"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Fire",
-                        "Colorless"
-                    ],
-                    "name": "Continuous Headbutt",
-                    "text": "Flip a coin until you get tails. This attack does 30 damage times the number of heads.",
-                    "damage": "30×",
-                    "convertedEnergyCost": 2
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Fairy",
-                    "value": "×2"
-                }
-            ]
-        },
-        {
-            "id": "xy6-55",
-            "name": "Bagon",
-            "nationalPokedexNumber": 371,
-            "imageUrl": "https://images.pokemontcg.io/xy6/55.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy6/55_hires.png",
-            "subtype": "Basic",
-            "supertype": "Pokémon",
-            "hp": "60",
-            "retreatCost": [
-                "Colorless"
-            ],
-            "number": "55",
-            "artist": "kirisAki",
-            "rarity": "Common",
-            "series": "XY",
-            "set": "Roaring Skies",
-            "setCode": "xy6",
-            "types": [
-                "Dragon"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Colorless"
-                    ],
-                    "name": "Leer",
-                    "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.",
-                    "damage": "",
-                    "convertedEnergyCost": 1
-                },
-                {
-                    "cost": [
-                        "Fire",
-                        "Water"
-                    ],
-                    "name": "Almost Flight",
-                    "text": "This Pokémon does 10 damage to itself.",
-                    "damage": "30",
-                    "convertedEnergyCost": 2
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Fairy",
-                    "value": "×2"
-                }
-            ]
-        },
-        {
-            "id": "xy6-63",
-            "name": "Reshiram",
-            "nationalPokedexNumber": 643,
-            "imageUrl": "https://images.pokemontcg.io/xy6/63.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy6/63_hires.png",
-            "subtype": "Basic",
-            "supertype": "Pokémon",
-            "ability": {
-                "name": "Turboblaze",
-                "text": "Once during your turn (before your attack), if this Pokémon is your Active Pokémon, you may attach a Fire Energy card from your hand to 1 of your Dragon Pokémon."
-            },
-            "hp": "130",
-            "retreatCost": [
-                "Colorless",
-                "Colorless"
-            ],
-            "number": "63",
-            "artist": "Kouki Saitou",
-            "rarity": "Rare Holo",
-            "series": "XY",
-            "set": "Roaring Skies",
-            "setCode": "xy6",
-            "types": [
-                "Dragon"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Fire",
-                        "Fire",
-                        "Lightning",
-                        "Colorless"
-                    ],
-                    "name": "Bright Wing",
-                    "text": "Discard a Fire Energy attached to this Pokémon.",
-                    "damage": "110",
-                    "convertedEnergyCost": 4
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Fairy",
-                    "value": "×2"
-                }
-            ]
-        },
-        {
-            "id": "xy6-64",
-            "name": "Zekrom",
-            "nationalPokedexNumber": 644,
-            "imageUrl": "https://images.pokemontcg.io/xy6/64.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy6/64_hires.png",
-            "subtype": "Basic",
-            "supertype": "Pokémon",
-            "hp": "130",
-            "retreatCost": [
-                "Colorless",
-                "Colorless"
-            ],
-            "number": "64",
-            "artist": "kawayoo",
-            "rarity": "Rare Holo",
-            "series": "XY",
-            "set": "Roaring Skies",
-            "setCode": "xy6",
-            "types": [
-                "Dragon"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Lightning"
-                    ],
-                    "name": "Energy Stream",
-                    "text": "Attach a basic Energy card from your discard pile to this Pokémon.",
-                    "damage": "30",
-                    "convertedEnergyCost": 1
-                },
-                {
-                    "cost": [
-                        "Fire",
-                        "Lightning",
-                        "Lightning",
-                        "Colorless"
-                    ],
-                    "name": "Electric Ball",
-                    "text": "",
-                    "damage": "100",
-                    "convertedEnergyCost": 4
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Fairy",
-                    "value": "×2"
-                }
-            ]
-        },
-        {
-            "id": "xy6-65",
-            "name": "Spearow",
-            "nationalPokedexNumber": 21,
-            "imageUrl": "https://images.pokemontcg.io/xy6/65.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy6/65_hires.png",
-            "subtype": "Basic",
-            "supertype": "Pokémon",
-            "hp": "60",
-            "retreatCost": [
-                "Colorless"
-            ],
-            "number": "65",
-            "artist": "Masakazu Fukuda",
-            "rarity": "Common",
-            "series": "XY",
-            "set": "Roaring Skies",
-            "setCode": "xy6",
-            "types": [
-                "Colorless"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Colorless",
-                        "Colorless"
-                    ],
-                    "name": "Peck",
-                    "text": "",
-                    "damage": "30",
-                    "convertedEnergyCost": 2
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Lightning",
-                    "value": "×2"
-                }
-            ],
-            "resistances": [
-                {
-                    "type": "Fighting",
-                    "value": "-20"
-                }
-            ]
-        },
-        {
-            "id": "xy6-67",
-            "name": "Meowth",
-            "nationalPokedexNumber": 52,
-            "imageUrl": "https://images.pokemontcg.io/xy6/67.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy6/67_hires.png",
-            "subtype": "Basic",
-            "supertype": "Pokémon",
-            "hp": "60",
-            "retreatCost": [
-                "Colorless"
-            ],
-            "number": "67",
-            "artist": "Akira Komayama",
-            "rarity": "Common",
-            "series": "XY",
-            "set": "Roaring Skies",
-            "setCode": "xy6",
-            "types": [
-                "Colorless"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Colorless"
-                    ],
-                    "name": "Feelin' Fine",
-                    "text": "Draw a card.",
-                    "damage": "",
-                    "convertedEnergyCost": 1
-                },
-                {
-                    "cost": [
-                        "Colorless",
-                        "Colorless",
-                        "Colorless"
-                    ],
-                    "name": "Fury Swipes",
-                    "text": "Flip 3 coins. This attack does 20 damage times the number of heads.",
-                    "damage": "20×",
-                    "convertedEnergyCost": 3
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Fighting",
-                    "value": "×2"
-                }
-            ]
-        },
-        {
-            "id": "xy6-69",
-            "name": "Skarmory",
-            "nationalPokedexNumber": 227,
-            "imageUrl": "https://images.pokemontcg.io/xy6/69.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy6/69_hires.png",
-            "subtype": "Basic",
-            "supertype": "Pokémon",
-            "hp": "100",
-            "retreatCost": [
-                "Colorless"
-            ],
-            "number": "69",
-            "artist": "Hitoshi Ariga",
-            "rarity": "Rare",
-            "series": "XY",
-            "set": "Roaring Skies",
-            "setCode": "xy6",
-            "types": [
-                "Colorless"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Colorless"
-                    ],
-                    "name": "Call for Family",
-                    "text": "Search your deck for up to 2 Basic Pokémon and put them onto your Bench. Shuffle your deck afterward.",
-                    "damage": "",
-                    "convertedEnergyCost": 1
-                },
-                {
-                    "cost": [
-                        "Colorless",
-                        "Colorless"
-                    ],
-                    "name": "Blow Through",
-                    "text": "If there is any Stadium card in play, this attack does 30 more damage.",
-                    "damage": "30+",
-                    "convertedEnergyCost": 2
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Lightning",
-                    "value": "×2"
-                }
-            ],
-            "resistances": [
-                {
-                    "type": "Fighting",
-                    "value": "-20"
-                }
-            ]
-        },
-        {
-            "id": "xy6-70",
-            "name": "Taillow",
-            "nationalPokedexNumber": 276,
-            "imageUrl": "https://images.pokemontcg.io/xy6/70.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy6/70_hires.png",
-            "subtype": "Basic",
-            "supertype": "Pokémon",
-            "hp": "50",
-            "retreatCost": [
-                "Colorless"
-            ],
-            "number": "70",
-            "artist": "Atsuko Nishida",
-            "rarity": "Common",
-            "series": "XY",
-            "set": "Roaring Skies",
-            "setCode": "xy6",
-            "types": [
-                "Colorless"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Colorless"
-                    ],
-                    "name": "Double Peck",
-                    "text": "Flip 2 coins. This attack does 10 damage times the number of heads.",
-                    "damage": "10×",
-                    "convertedEnergyCost": 1
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Lightning",
-                    "value": "×2"
-                }
-            ],
-            "resistances": [
-                {
-                    "type": "Fighting",
-                    "value": "-20"
-                }
-            ]
-        },
-        {
-            "id": "xy6-73",
-            "name": "Swablu",
-            "nationalPokedexNumber": 333,
-            "imageUrl": "https://images.pokemontcg.io/xy6/73.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy6/73_hires.png",
-            "subtype": "Basic",
-            "supertype": "Pokémon",
-            "hp": "40",
-            "retreatCost": [
-                "Colorless"
-            ],
-            "number": "73",
-            "artist": "Mizue",
-            "rarity": "Common",
-            "series": "XY",
-            "set": "Roaring Skies",
-            "setCode": "xy6",
-            "types": [
-                "Colorless"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Colorless"
-                    ],
-                    "name": "Bind Wound",
-                    "text": "Heal 20 damage from 1 of your Pokémon.",
-                    "damage": "",
-                    "convertedEnergyCost": 1
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Lightning",
-                    "value": "×2"
-                }
-            ],
-            "resistances": [
-                {
-                    "type": "Fighting",
-                    "value": "-20"
-                }
-            ]
-        },
-        {
-            "id": "xy6-78",
-            "name": "Pidove",
-            "nationalPokedexNumber": 519,
-            "imageUrl": "https://images.pokemontcg.io/xy6/78.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy6/78_hires.png",
-            "subtype": "Basic",
-            "supertype": "Pokémon",
-            "hp": "60",
-            "retreatCost": [
-                "Colorless"
-            ],
-            "number": "78",
-            "artist": "kirisAki",
-            "rarity": "Common",
-            "series": "XY",
-            "set": "Roaring Skies",
-            "setCode": "xy6",
-            "types": [
-                "Colorless"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Colorless"
-                    ],
-                    "name": "Homing Pidove",
-                    "text": "Look at the top card of your deck. Then, you may shuffle your deck.",
-                    "damage": "",
-                    "convertedEnergyCost": 1
-                },
-                {
-                    "cost": [
-                        "Colorless",
-                        "Colorless"
-                    ],
-                    "name": "Gust",
-                    "text": "",
-                    "damage": "20",
-                    "convertedEnergyCost": 2
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Lightning",
-                    "value": "×2"
-                }
-            ],
-            "resistances": [
-                {
-                    "type": "Fighting",
-                    "value": "-20"
-                }
-            ]
-        },
-        {
-            "id": "xy6-82",
-            "name": "Fletchling",
-            "nationalPokedexNumber": 661,
-            "imageUrl": "https://images.pokemontcg.io/xy6/82.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy6/82_hires.png",
-            "subtype": "Basic",
-            "supertype": "Pokémon",
-            "hp": "40",
-            "retreatCost": [
-                "Colorless"
-            ],
-            "number": "82",
-            "artist": "Kanako Eo",
-            "rarity": "Common",
-            "series": "XY",
-            "set": "Roaring Skies",
-            "setCode": "xy6",
-            "types": [
-                "Colorless"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Colorless"
-                    ],
-                    "name": "Acrobatics",
-                    "text": "Flip 2 coins. This attack does 10 more damage for each heads.",
-                    "damage": "10+",
-                    "convertedEnergyCost": 1
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Lightning",
-                    "value": "×2"
-                }
-            ],
-            "resistances": [
-                {
-                    "type": "Fighting",
-                    "value": "-20"
-                }
-            ]
+          "name": "Ram",
+          "cost": [
+            "Grass"
+          ],
+          "convertedEnergyCost": 1,
+          "damage": "10",
+          "text": ""
         }
-    ]
+      ],
+      "weaknesses": [
+        {
+          "type": "Fire",
+          "value": "×2"
+        }
+      ],
+      "retreatCost": [
+        "Colorless"
+      ],
+      "convertedRetreatCost": 1,
+      "set": {
+        "id": "xy6",
+        "name": "Roaring Skies",
+        "series": "XY",
+        "printedTotal": 108,
+        "total": 110,
+        "legalities": {
+          "unlimited": "Legal",
+          "expanded": "Legal"
+        },
+        "ptcgoCode": "ROS",
+        "releaseDate": "2015/05/06",
+        "updatedAt": "2020/08/14 09:35:00",
+        "images": {
+          "symbol": "https://images.pokemontcg.io/xy6/symbol.png",
+          "logo": "https://images.pokemontcg.io/xy6/logo.png"
+        }
+      },
+      "number": "1",
+      "artist": "Tomokazu Komiya",
+      "rarity": "Common",
+      "flavorText": "Even though it appears to be eggs of some sort, it was discovered to be a life-form more like plant seeds.",
+      "nationalPokedexNumbers": [
+        102
+      ],
+      "legalities": {
+        "unlimited": "Legal",
+        "expanded": "Legal"
+      },
+      "images": {
+        "small": "https://images.pokemontcg.io/xy6/1.png",
+        "large": "https://images.pokemontcg.io/xy6/1_hires.png"
+      },
+      "tcgplayer": {
+        "url": "https://prices.pokemontcg.io/tcgplayer/xy6-1",
+        "updatedAt": "2021/03/12",
+        "prices": {
+          "normal": {
+            "low": 0.05,
+            "mid": 0.2,
+            "high": 1.2,
+            "market": 0.12,
+            "directLow": 0.07
+          },
+          "reverseHolofoil": {
+            "low": 0.07,
+            "mid": 0.32,
+            "high": 1.95,
+            "market": 0.22,
+            "directLow": 0.07
+          }
+        }
+      }
+    },
+    {
+      "id": "xy6-3",
+      "name": "Wurmple",
+      "supertype": "Pokémon",
+      "subtypes": [
+        "Basic"
+      ],
+      "hp": "60",
+      "types": [
+        "Grass"
+      ],
+      "evolvesTo": [
+        "Silcoon",
+        "Cascoon"
+      ],
+      "attacks": [
+        {
+          "name": "Flock",
+          "cost": [
+            "Grass"
+          ],
+          "convertedEnergyCost": 1,
+          "damage": "",
+          "text": "Search your deck for Wurmple and put it onto your Bench. Shuffle your deck afterward."
+        },
+        {
+          "name": "Tackle",
+          "cost": [
+            "Colorless",
+            "Colorless"
+          ],
+          "convertedEnergyCost": 2,
+          "damage": "20",
+          "text": ""
+        }
+      ],
+      "weaknesses": [
+        {
+          "type": "Fire",
+          "value": "×2"
+        }
+      ],
+      "retreatCost": [
+        "Colorless"
+      ],
+      "convertedRetreatCost": 1,
+      "set": {
+        "id": "xy6",
+        "name": "Roaring Skies",
+        "series": "XY",
+        "printedTotal": 108,
+        "total": 110,
+        "legalities": {
+          "unlimited": "Legal",
+          "expanded": "Legal"
+        },
+        "ptcgoCode": "ROS",
+        "releaseDate": "2015/05/06",
+        "updatedAt": "2020/08/14 09:35:00",
+        "images": {
+          "symbol": "https://images.pokemontcg.io/xy6/symbol.png",
+          "logo": "https://images.pokemontcg.io/xy6/logo.png"
+        }
+      },
+      "number": "3",
+      "artist": "Naoyo Kimura",
+      "rarity": "Common",
+      "flavorText": "It lives among the tall grass and in forests. It repels attacks by raising up the spikes on its rear.",
+      "nationalPokedexNumbers": [
+        265
+      ],
+      "legalities": {
+        "unlimited": "Legal",
+        "expanded": "Legal"
+      },
+      "images": {
+        "small": "https://images.pokemontcg.io/xy6/3.png",
+        "large": "https://images.pokemontcg.io/xy6/3_hires.png"
+      },
+      "tcgplayer": {
+        "url": "https://prices.pokemontcg.io/tcgplayer/xy6-3",
+        "updatedAt": "2021/03/12",
+        "prices": {
+          "normal": {
+            "low": 0.04,
+            "mid": 0.2,
+            "high": 0.99,
+            "market": 0.07,
+            "directLow": null
+          },
+          "reverseHolofoil": {
+            "low": 0.09,
+            "mid": 0.3,
+            "high": 1.95,
+            "market": 0.23,
+            "directLow": 0.15
+          }
+        }
+      }
+    },
+    {
+      "id": "xy6-9",
+      "name": "Nincada",
+      "supertype": "Pokémon",
+      "subtypes": [
+        "Basic"
+      ],
+      "hp": "40",
+      "types": [
+        "Grass"
+      ],
+      "evolvesTo": [
+        "Ninjask"
+      ],
+      "attacks": [
+        {
+          "name": "Slight Intrusion",
+          "cost": [
+            "Colorless"
+          ],
+          "convertedEnergyCost": 1,
+          "damage": "20",
+          "text": "This Pokémon does 10 damage to itself."
+        }
+      ],
+      "weaknesses": [
+        {
+          "type": "Fire",
+          "value": "×2"
+        }
+      ],
+      "retreatCost": [
+        "Colorless"
+      ],
+      "convertedRetreatCost": 1,
+      "set": {
+        "id": "xy6",
+        "name": "Roaring Skies",
+        "series": "XY",
+        "printedTotal": 108,
+        "total": 110,
+        "legalities": {
+          "unlimited": "Legal",
+          "expanded": "Legal"
+        },
+        "ptcgoCode": "ROS",
+        "releaseDate": "2015/05/06",
+        "updatedAt": "2020/08/14 09:35:00",
+        "images": {
+          "symbol": "https://images.pokemontcg.io/xy6/symbol.png",
+          "logo": "https://images.pokemontcg.io/xy6/logo.png"
+        }
+      },
+      "number": "9",
+      "artist": "Kyoko Umemoto",
+      "rarity": "Common",
+      "flavorText": "It can sometimes live underground for more than 10 years. It absorbs nutrients from the roots of trees.",
+      "nationalPokedexNumbers": [
+        290
+      ],
+      "legalities": {
+        "unlimited": "Legal",
+        "expanded": "Legal"
+      },
+      "images": {
+        "small": "https://images.pokemontcg.io/xy6/9.png",
+        "large": "https://images.pokemontcg.io/xy6/9_hires.png"
+      },
+      "tcgplayer": {
+        "url": "https://prices.pokemontcg.io/tcgplayer/xy6-9",
+        "updatedAt": "2021/03/12",
+        "prices": {
+          "normal": {
+            "low": 0.02,
+            "mid": 0.2,
+            "high": 0.99,
+            "market": 0.08,
+            "directLow": 0.06
+          },
+          "reverseHolofoil": {
+            "low": 0.09,
+            "mid": 0.3,
+            "high": 1.95,
+            "market": 0.24,
+            "directLow": 0.09
+          }
+        }
+      }
+    },
+    {
+      "id": "xy6-12",
+      "name": "Tropius",
+      "supertype": "Pokémon",
+      "subtypes": [
+        "Basic"
+      ],
+      "hp": "110",
+      "types": [
+        "Grass"
+      ],
+      "attacks": [
+        {
+          "name": "Stomp",
+          "cost": [
+            "Colorless",
+            "Colorless",
+            "Colorless"
+          ],
+          "convertedEnergyCost": 3,
+          "damage": "50+",
+          "text": "Flip a coin. If heads, this attack does 20 more damage."
+        },
+        {
+          "name": "Solar Beam",
+          "cost": [
+            "Grass",
+            "Colorless",
+            "Colorless",
+            "Colorless"
+          ],
+          "convertedEnergyCost": 4,
+          "damage": "80",
+          "text": ""
+        }
+      ],
+      "weaknesses": [
+        {
+          "type": "Fire",
+          "value": "×2"
+        }
+      ],
+      "retreatCost": [
+        "Colorless",
+        "Colorless"
+      ],
+      "convertedRetreatCost": 2,
+      "set": {
+        "id": "xy6",
+        "name": "Roaring Skies",
+        "series": "XY",
+        "printedTotal": 108,
+        "total": 110,
+        "legalities": {
+          "unlimited": "Legal",
+          "expanded": "Legal"
+        },
+        "ptcgoCode": "ROS",
+        "releaseDate": "2015/05/06",
+        "updatedAt": "2020/08/14 09:35:00",
+        "images": {
+          "symbol": "https://images.pokemontcg.io/xy6/symbol.png",
+          "logo": "https://images.pokemontcg.io/xy6/logo.png"
+        }
+      },
+      "number": "12",
+      "artist": "Kyoko Umemoto",
+      "rarity": "Uncommon",
+      "flavorText": "The bunch of fruit around its neck ripens twice a year and is delicious. It's a highly favored tropical snack.",
+      "nationalPokedexNumbers": [
+        357
+      ],
+      "legalities": {
+        "unlimited": "Legal",
+        "expanded": "Legal"
+      },
+      "images": {
+        "small": "https://images.pokemontcg.io/xy6/12.png",
+        "large": "https://images.pokemontcg.io/xy6/12_hires.png"
+      },
+      "tcgplayer": {
+        "url": "https://prices.pokemontcg.io/tcgplayer/xy6-12",
+        "updatedAt": "2021/03/12",
+        "prices": {
+          "normal": {
+            "low": 0.05,
+            "mid": 0.25,
+            "high": 0.99,
+            "market": 0.09,
+            "directLow": 0.06
+          },
+          "reverseHolofoil": {
+            "low": 0.14,
+            "mid": 0.32,
+            "high": 1.95,
+            "market": 0.21,
+            "directLow": 0.21
+          }
+        }
+      }
+    }
+  ],
+  "page": 1,
+  "pageSize": 250,
+  "count": 4,
+  "totalCount": 4
 }

--- a/tests/lib/fixtures/cards/find.json
+++ b/tests/lib/fixtures/cards/find.json
@@ -1,54 +1,96 @@
 {
-    "card": {
-        "id": "xy7-57",
-        "name": "Giratina-EX",
-        "nationalPokedexNumber": 487,
-        "imageUrl": "https://images.pokemontcg.io/xy7/54.png",
-        "imageUrlHiRes": "https://images.pokemontcg.io/xy7/54_hires.png",
-        "subtype": "EX",
-        "supertype": "Pokémon",
-        "ability": {
-            "name": "Renegade Pulse",
-            "text": "Prevent all effects of attacks, including damage, done to this Pokémon by your opponent's Mega Evolution Pokémon.",
-            "type": "Ability"
-        },
-        "hp": "170",
-        "retreatCost": [
-            "Colorless",
-            "Colorless",
-            "Colorless"
+  "data": {
+    "id": "xy7-57",
+    "name": "Giratina-EX",
+    "supertype": "Pokémon",
+    "subtypes": [
+      "Basic",
+      "EX"
+    ],
+    "hp": "170",
+    "types": [
+      "Dragon"
+    ],
+    "rules": [
+      "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
+    ],
+    "abilities": [
+      {
+        "name": "Renegade Pulse",
+        "text": "Prevent all effects of attacks, including damage, done to this Pokémon by your opponent's Mega Evolution Pokémon.",
+        "type": "Ability"
+      }
+    ],
+    "attacks": [
+      {
+        "name": "Chaos Wheel",
+        "cost": [
+          "Grass",
+          "Psychic",
+          "Colorless",
+          "Colorless"
         ],
-        "number": "57",
-        "artist": "PLANETA",
-        "rarity": "Rare Holo EX",
-        "series": "XY",
-        "set": "Ancient Origins",
-        "setCode": "xy7",
-        "text": [
-            "When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
-        ],
-        "types": [
-            "Dragon"
-        ],
-        "attacks": [
-            {
-                "cost": [
-                    "Grass",
-                    "Psychic",
-                    "Colorless",
-                    "Colorless"
-                ],
-                "name": "Chaos Wheel",
-                "text": "Your opponent can't play any Pokémon Tool, Special Energy, or Stadium cards from his or her hand during his or her next turn.",
-                "damage": "100",
-                "convertedEnergyCost": 4
-            }
-        ],
-        "weaknesses": [
-            {
-                "type": "Fairy",
-                "value": "×2"
-            }
-        ]
+        "convertedEnergyCost": 4,
+        "damage": "100",
+        "text": "Your opponent can't play any Pokémon Tool, Special Energy, or Stadium cards from his or her hand during his or her next turn."
+      }
+    ],
+    "weaknesses": [
+      {
+        "type": "Fairy",
+        "value": "×2"
+      }
+    ],
+    "retreatCost": [
+      "Colorless",
+      "Colorless",
+      "Colorless"
+    ],
+    "convertedRetreatCost": 3,
+    "set": {
+      "id": "xy7",
+      "name": "Ancient Origins",
+      "series": "XY",
+      "printedTotal": 98,
+      "total": 100,
+      "legalities": {
+        "unlimited": "Legal",
+        "expanded": "Legal"
+      },
+      "ptcgoCode": "AOR",
+      "releaseDate": "2015/08/12",
+      "updatedAt": "2020/08/14 09:35:00",
+      "images": {
+        "symbol": "https://images.pokemontcg.io/xy7/symbol.png",
+        "logo": "https://images.pokemontcg.io/xy7/logo.png"
+      }
+    },
+    "number": "57",
+    "artist": "PLANETA",
+    "rarity": "Rare Holo EX",
+    "nationalPokedexNumbers": [
+      487
+    ],
+    "legalities": {
+      "unlimited": "Legal",
+      "expanded": "Legal"
+    },
+    "images": {
+      "small": "https://images.pokemontcg.io/xy7/57.png",
+      "large": "https://images.pokemontcg.io/xy7/57_hires.png"
+    },
+    "tcgplayer": {
+      "url": "https://prices.pokemontcg.io/tcgplayer/xy7-57",
+      "updatedAt": "2021/03/12",
+      "prices": {
+        "holofoil": {
+          "low": 3.7,
+          "mid": 8.0,
+          "high": 14.9,
+          "market": 6.0,
+          "directLow": 9.99
+        }
+      }
     }
+  }
 }

--- a/tests/lib/fixtures/cards/page.json
+++ b/tests/lib/fixtures/cards/page.json
@@ -1,413 +1,939 @@
 {
-    "cards": [
+  "data": [
+    {
+      "id": "pl1-1",
+      "name": "Ampharos",
+      "supertype": "Pokémon",
+      "subtypes": [
+        "Stage 2"
+      ],
+      "level": "57",
+      "hp": "130",
+      "types": [
+        "Lightning"
+      ],
+      "evolvesFrom": "Flaaffy",
+      "abilities": [
         {
-            "id": "xy7-1",
-            "name": "Oddish",
-            "nationalPokedexNumber": 43,
-            "imageUrl": "https://images.pokemontcg.io/xy7/1.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy7/1_hires.png",
-            "subtype": "Basic",
-            "supertype": "Pokémon",
-            "hp": "50",
-            "retreatCost": [
-                "Colorless"
-            ],
-            "number": "1",
-            "artist": "MAHOU",
-            "rarity": "Common",
-            "series": "XY",
-            "set": "Ancient Origins",
-            "setCode": "xy7",
-            "types": [
-                "Grass"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Grass"
-                    ],
-                    "name": "Trip Over",
-                    "text": "Flip a coin. If heads, this attack does 10 more damage.",
-                    "damage": "10+",
-                    "convertedEnergyCost": 1
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Fire",
-                    "value": "×2"
-                }
-            ]
-        },
-        {
-            "id": "xy7-2",
-            "name": "Gloom",
-            "nationalPokedexNumber": 44,
-            "imageUrl": "https://images.pokemontcg.io/xy7/2.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy7/2_hires.png",
-            "subtype": "Stage 1",
-            "supertype": "Pokémon",
-            "hp": "80",
-            "retreatCost": [
-                "Colorless"
-            ],
-            "number": "2",
-            "artist": "Masakazu Fukuda",
-            "rarity": "Uncommon",
-            "series": "XY",
-            "set": "Ancient Origins",
-            "setCode": "xy7",
-            "types": [
-                "Grass"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Grass",
-                        "Colorless"
-                    ],
-                    "name": "Drool",
-                    "text": "",
-                    "damage": "30",
-                    "convertedEnergyCost": 2
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Fire",
-                    "value": "×2"
-                }
-            ]
-        },
-        {
-            "id": "xy7-3",
-            "name": "Vileplume",
-            "nationalPokedexNumber": 45,
-            "imageUrl": "https://images.pokemontcg.io/xy7/3.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy7/3_hires.png",
-            "subtype": "Stage 2",
-            "supertype": "Pokémon",
-            "ability": {
-                "name": "Irritating Pollen",
-                "text": "Each player can't play any Item cards from his or her hand."
-            },
-            "hp": "130",
-            "retreatCost": [
-                "Colorless",
-                "Colorless",
-                "Colorless"
-            ],
-            "number": "3",
-            "artist": "Midori Harada",
-            "rarity": "Rare",
-            "series": "XY",
-            "set": "Ancient Origins",
-            "setCode": "xy7",
-            "types": [
-                "Grass"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Grass",
-                        "Grass",
-                        "Colorless"
-                    ],
-                    "name": "Solar Beam",
-                    "text": "",
-                    "damage": "70",
-                    "convertedEnergyCost": 3
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Fire",
-                    "value": "×2"
-                }
-            ]
-        },
-        {
-            "id": "xy7-4",
-            "name": "Bellossom",
-            "nationalPokedexNumber": 182,
-            "imageUrl": "https://images.pokemontcg.io/xy7/4.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy7/4_hires.png",
-            "subtype": "Stage 2",
-            "supertype": "Pokémon",
-            "hp": "120",
-            "retreatCost": [
-                "Colorless"
-            ],
-            "number": "4",
-            "artist": "Mizue",
-            "rarity": "Uncommon",
-            "series": "XY",
-            "set": "Ancient Origins",
-            "setCode": "xy7",
-            "types": [
-                "Grass"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Grass"
-                    ],
-                    "name": "Windmill",
-                    "text": "Switch this Pokémon with 1 of your Benched Pokémon.",
-                    "damage": "20",
-                    "convertedEnergyCost": 1
-                },
-                {
-                    "cost": [
-                        "Grass",
-                        "Colorless"
-                    ],
-                    "name": "Flower Tornado",
-                    "text": "Move as many Grass Energy attached to your Pokémon to your other Pokémon in any way you like.",
-                    "damage": "60",
-                    "convertedEnergyCost": 2
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Fire",
-                    "value": "×2"
-                }
-            ]
-        },
-        {
-            "id": "xy7-5",
-            "name": "Spinarak",
-            "nationalPokedexNumber": 167,
-            "imageUrl": "https://images.pokemontcg.io/xy7/5.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy7/5_hires.png",
-            "subtype": "Basic",
-            "supertype": "Pokémon",
-            "hp": "50",
-            "retreatCost": [
-                "Colorless"
-            ],
-            "number": "5",
-            "artist": "Naoyo Kimura",
-            "rarity": "Common",
-            "series": "XY",
-            "set": "Ancient Origins",
-            "setCode": "xy7",
-            "types": [
-                "Grass"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Colorless"
-                    ],
-                    "name": "String Shot",
-                    "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.",
-                    "damage": "",
-                    "convertedEnergyCost": 1
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Fire",
-                    "value": "×2"
-                }
-            ]
-        },
-        {
-            "id": "xy7-6",
-            "name": "Ariados",
-            "nationalPokedexNumber": 168,
-            "imageUrl": "https://images.pokemontcg.io/xy7/6.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy7/6_hires.png",
-            "subtype": "Stage 1",
-            "supertype": "Pokémon",
-            "ability": {
-                "name": "Poisonous Nest",
-                "text": "Once during your turn (before your attack), you may use this Ability. Both Active Pokémon (except for Grass Pokémon) are now Poisoned."
-            },
-            "hp": "70",
-            "retreatCost": [
-                "Colorless"
-            ],
-            "number": "6",
-            "artist": "Hajime Kusajima",
-            "rarity": "Uncommon",
-            "series": "XY",
-            "set": "Ancient Origins",
-            "setCode": "xy7",
-            "types": [
-                "Grass"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Grass",
-                        "Colorless"
-                    ],
-                    "name": "Impound",
-                    "text": "The Defending Pokémon can't retreat during your opponent's next turn.",
-                    "damage": "30",
-                    "convertedEnergyCost": 2
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Fire",
-                    "value": "×2"
-                }
-            ]
-        },
-        {
-            "id": "xy7-7",
-            "name": "Sceptile-EX",
-            "nationalPokedexNumber": 254,
-            "imageUrl": "https://images.pokemontcg.io/xy7/7.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy7/7_hires.png",
-            "subtype": "EX",
-            "supertype": "Pokémon",
-            "hp": "170",
-            "retreatCost": [
-                "Colorless"
-            ],
-            "number": "7",
-            "artist": "Eske Yoshinob",
-            "rarity": "Rare Holo EX",
-            "series": "XY",
-            "set": "Ancient Origins",
-            "setCode": "xy7",
-            "text": [
-                "When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
-            ],
-            "types": [
-                "Grass"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Grass"
-                    ],
-                    "name": "Sleep Poison",
-                    "text": "Flip a coin. If heads, your opponent's Active Pokémon is now Asleep and Poisoned.",
-                    "damage": "10",
-                    "convertedEnergyCost": 1
-                },
-                {
-                    "cost": [
-                        "Grass",
-                        "Colorless"
-                    ],
-                    "name": "Unseen Claw",
-                    "text": "If your opponent's Active Pokémon is affected by a Special Condition, this attack does 70 more damage.",
-                    "damage": "60+",
-                    "convertedEnergyCost": 2
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Fire",
-                    "value": "×2"
-                }
-            ]
-        },
-        {
-            "id": "xy7-8",
-            "name": "M Sceptile-EX",
-            "nationalPokedexNumber": 254,
-            "imageUrl": "https://images.pokemontcg.io/xy7/8.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy7/8_hires.png",
-            "subtype": "MEGA",
-            "supertype": "Pokémon",
-            "hp": "220",
-            "retreatCost": [
-                "Colorless",
-                "Colorless"
-            ],
-            "number": "8",
-            "artist": "5ban Graphics",
-            "rarity": "Rare Holo EX",
-            "series": "XY",
-            "set": "Ancient Origins",
-            "setCode": "xy7",
-            "text": [
-                "When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards.",
-                "Prevent all effects of your opponent's Pokémon's Abilities done to this Pokémon.",
-                "When 1 of your Pokémon becomes a Mega Evolution Pokémon, your turn ends."
-            ],
-            "types": [
-                "Grass"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Grass",
-                        "Colorless"
-                    ],
-                    "name": "Jagged Saber",
-                    "text": "You may attach up to 2 Grass Energy cards from your hand to your Benched Pokémon in any way you like. If you attached Energy to a Pokémon in this way, heal all damage from that Pokémon.",
-                    "damage": "100",
-                    "convertedEnergyCost": 2
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Fire",
-                    "value": "×2"
-                }
-            ]
-        },
-        {
-            "id": "xy7-9",
-            "name": "Combee",
-            "nationalPokedexNumber": 415,
-            "imageUrl": "https://images.pokemontcg.io/xy7/9.png",
-            "imageUrlHiRes": "https://images.pokemontcg.io/xy7/9_hires.png",
-            "subtype": "Basic",
-            "supertype": "Pokémon",
-            "hp": "40",
-            "retreatCost": [
-                "Colorless"
-            ],
-            "number": "9",
-            "artist": "Sumiyoshi Kizuki",
-            "rarity": "Common",
-            "series": "XY",
-            "set": "Ancient Origins",
-            "setCode": "xy7",
-            "types": [
-                "Grass"
-            ],
-            "attacks": [
-                {
-                    "cost": [
-                        "Grass"
-                    ],
-                    "name": "Bug Bite",
-                    "text": "",
-                    "damage": "10",
-                    "convertedEnergyCost": 1
-                }
-            ],
-            "weaknesses": [
-                {
-                    "type": "Fire",
-                    "value": "×2"
-                }
-            ]
-        },
-        {
-            "id": "gym1-132",
-            "name": "Water Energy",
-            "imageUrl": "https://images.pokemontcg.io/gym1/132.jpg",
-            "imageUrlHiRes": "https://images.pokemontcg.io/gym1/132_hires.jpg",
-            "subtype": "Basic",
-            "supertype": "Energy",
-            "number": "132",
-            "artist": "Keiji Kinebuchi",
-            "rarity": "Common",
-            "series": "Gym",
-            "set": "Gym Heroes",
-            "setCode": "gym1"
+          "name": "Damage Bind",
+          "text": "Each Pokémon that has any damage counters on it (both yours and your opponent's) can't use any Poké-Powers.",
+          "type": "Poké-Body"
         }
-    ]
+      ],
+      "attacks": [
+        {
+          "name": "Gigavolt",
+          "cost": [
+            "Lightning",
+            "Colorless"
+          ],
+          "convertedEnergyCost": 2,
+          "damage": "30+",
+          "text": "Flip a coin. If heads, this attack does 30 damage plus 30 more damage. If tails, the Defending Pokémon is now Paralyzed."
+        },
+        {
+          "name": "Reflect Energy",
+          "cost": [
+            "Lightning",
+            "Colorless",
+            "Colorless"
+          ],
+          "convertedEnergyCost": 3,
+          "damage": "70",
+          "text": "Move an Energy card attached to Ampharos to 1 of your Benched Pokémon."
+        }
+      ],
+      "weaknesses": [
+        {
+          "type": "Fighting",
+          "value": "+30"
+        }
+      ],
+      "resistances": [
+        {
+          "type": "Metal",
+          "value": "-20"
+        }
+      ],
+      "retreatCost": [
+        "Colorless",
+        "Colorless"
+      ],
+      "convertedRetreatCost": 2,
+      "set": {
+        "id": "pl1",
+        "name": "Platinum",
+        "series": "Platinum",
+        "printedTotal": 127,
+        "total": 130,
+        "legalities": {
+          "unlimited": "Legal"
+        },
+        "ptcgoCode": "PL",
+        "releaseDate": "2009/02/11",
+        "updatedAt": "2020/08/14 09:35:00",
+        "images": {
+          "symbol": "https://images.pokemontcg.io/pl1/symbol.png",
+          "logo": "https://images.pokemontcg.io/pl1/logo.png"
+        }
+      },
+      "number": "1",
+      "artist": "Atsuko Nishida",
+      "rarity": "Rare Holo",
+      "nationalPokedexNumbers": [
+        181
+      ],
+      "legalities": {
+        "unlimited": "Legal"
+      },
+      "images": {
+        "small": "https://images.pokemontcg.io/pl1/1.png",
+        "large": "https://images.pokemontcg.io/pl1/1_hires.png"
+      },
+      "tcgplayer": {
+        "url": "https://prices.pokemontcg.io/tcgplayer/pl1-1",
+        "updatedAt": "2021/03/12",
+        "prices": {
+          "holofoil": {
+            "low": 5.68,
+            "mid": 7.04,
+            "high": 8.99,
+            "market": 3.56,
+            "directLow": null
+          },
+          "reverseHolofoil": {
+            "low": 5.58,
+            "mid": 10.29,
+            "high": 15.0,
+            "market": 2.16,
+            "directLow": null
+          }
+        }
+      }
+    },
+    {
+      "id": "det1-1",
+      "name": "Bulbasaur",
+      "supertype": "Pokémon",
+      "subtypes": [
+        "Basic"
+      ],
+      "hp": "60",
+      "types": [
+        "Grass"
+      ],
+      "evolvesTo": [
+        "Ivysaur"
+      ],
+      "attacks": [
+        {
+          "name": "Find a Friend",
+          "cost": [
+            "Grass"
+          ],
+          "convertedEnergyCost": 1,
+          "damage": "",
+          "text": "Search your deck for a Grass Pokémon, reveal it, and put it into your hand. Then, shuffle your deck."
+        }
+      ],
+      "weaknesses": [
+        {
+          "type": "Fire",
+          "value": "×2"
+        }
+      ],
+      "retreatCost": [
+        "Colorless"
+      ],
+      "convertedRetreatCost": 1,
+      "set": {
+        "id": "det1",
+        "name": "Detective Pikachu",
+        "series": "Sun & Moon",
+        "printedTotal": 18,
+        "total": 18,
+        "legalities": {
+          "unlimited": "Legal",
+          "standard": "Legal",
+          "expanded": "Legal"
+        },
+        "ptcgoCode": "DET",
+        "releaseDate": "2019/04/05",
+        "updatedAt": "2019/04/25 22:26:00",
+        "images": {
+          "symbol": "https://images.pokemontcg.io/det1/symbol.png",
+          "logo": "https://images.pokemontcg.io/det1/logo.png"
+        }
+      },
+      "number": "1",
+      "artist": "MPC Film",
+      "rarity": "Common",
+      "flavorText": "A strange seed was planted on its back at birth. The plant sprouts and grows with this Pokémon.",
+      "nationalPokedexNumbers": [
+        1
+      ],
+      "legalities": {
+        "unlimited": "Legal",
+        "standard": "Legal",
+        "expanded": "Legal"
+      },
+      "images": {
+        "small": "https://images.pokemontcg.io/det1/1.png",
+        "large": "https://images.pokemontcg.io/det1/1_hires.png"
+      },
+      "tcgplayer": {
+        "url": "https://prices.pokemontcg.io/tcgplayer/det1-1",
+        "updatedAt": "2021/03/12",
+        "prices": {
+          "holofoil": {
+            "low": 0.1,
+            "mid": 0.41,
+            "high": 9.95,
+            "market": 0.31,
+            "directLow": 0.34
+          }
+        }
+      }
+    },
+    {
+      "id": "mcd19-1",
+      "name": "Caterpie",
+      "supertype": "Pokémon",
+      "subtypes": [
+        "Basic"
+      ],
+      "hp": "50",
+      "types": [
+        "Grass"
+      ],
+      "evolvesTo": [
+        "Metapod"
+      ],
+      "attacks": [
+        {
+          "cost": [
+            "Grass"
+          ],
+          "name": "Surprise Attack",
+          "text": "Flip a coin. If tails, this attack does nothing.",
+          "damage": "20",
+          "convertedEnergyCost": 1
+        }
+      ],
+      "retreatCost": [
+        "Colorless"
+      ],
+      "convertedRetreatCost": 1,
+      "set": {
+        "id": "mcd19",
+        "name": "McDonald's Collection 2019",
+        "series": "Other",
+        "printedTotal": 12,
+        "total": 12,
+        "legalities": {
+          "unlimited": "Legal"
+        },
+        "releaseDate": "2019/10/15",
+        "updatedAt": "2020/11/11 13:00:00",
+        "images": {
+          "symbol": "https://images.pokemontcg.io/mcd19/symbol.png",
+          "logo": "https://images.pokemontcg.io/mcd19/logo.png"
+        }
+      },
+      "number": "1",
+      "artist": "Sekio",
+      "rarity": "Promo",
+      "nationalPokedexNumbers": [
+        10
+      ],
+      "legalities": {
+        "unlimited": "Legal"
+      },
+      "images": {
+        "small": "https://images.pokemontcg.io/mcd19/1.png",
+        "large": "https://images.pokemontcg.io/mcd19/1_hires.png"
+      },
+      "tcgplayer": {
+        "url": "https://prices.pokemontcg.io/tcgplayer/mcd19-1",
+        "updatedAt": "2021/03/12",
+        "prices": {
+          "holofoil": {
+            "low": 12.75,
+            "mid": 12.99,
+            "high": 14.95,
+            "market": 6.14,
+            "directLow": null
+          }
+        }
+      }
+    },
+    {
+      "id": "dv1-1",
+      "name": "Dratini",
+      "supertype": "Pokémon",
+      "subtypes": [
+        "Basic"
+      ],
+      "hp": "40",
+      "types": [
+        "Dragon"
+      ],
+      "evolvesTo": [
+        "Dragonair"
+      ],
+      "attacks": [
+        {
+          "name": "Wrap",
+          "cost": [
+            "Grass",
+            "Lightning"
+          ],
+          "convertedEnergyCost": 2,
+          "damage": "20",
+          "text": "Flip a coin. If heads, the Defending Pokémon is now Paralyzed."
+        }
+      ],
+      "weaknesses": [
+        {
+          "type": "Dragon",
+          "value": "×2"
+        }
+      ],
+      "retreatCost": [
+        "Colorless"
+      ],
+      "convertedRetreatCost": 1,
+      "set": {
+        "id": "dv1",
+        "name": "Dragon Vault",
+        "series": "Black & White",
+        "printedTotal": 20,
+        "total": 20,
+        "legalities": {
+          "unlimited": "Legal",
+          "expanded": "Legal"
+        },
+        "ptcgoCode": "DRV",
+        "releaseDate": "2012/10/05",
+        "updatedAt": "2019/01/28 16:44:00",
+        "images": {
+          "symbol": "https://images.pokemontcg.io/dv1/symbol.png",
+          "logo": "https://images.pokemontcg.io/dv1/logo.png"
+        }
+      },
+      "number": "1",
+      "artist": "Masakazu Fukuda",
+      "rarity": "Rare Holo",
+      "flavorText": "It is called the \"Mirage Pokémon\" because so few have seen it. Its shed skin has been found.",
+      "nationalPokedexNumbers": [
+        147
+      ],
+      "legalities": {
+        "unlimited": "Legal",
+        "expanded": "Legal"
+      },
+      "images": {
+        "small": "https://images.pokemontcg.io/dv1/1.png",
+        "large": "https://images.pokemontcg.io/dv1/1_hires.png"
+      },
+      "tcgplayer": {
+        "url": "https://prices.pokemontcg.io/tcgplayer/dv1-1",
+        "updatedAt": "2021/03/12",
+        "prices": {
+          "holofoil": {
+            "low": 0.45,
+            "mid": 0.9,
+            "high": 3.28,
+            "market": 0.69,
+            "directLow": null
+          }
+        }
+      }
+    },
+    {
+      "id": "xy5-1",
+      "name": "Weedle",
+      "supertype": "Pokémon",
+      "subtypes": [
+        "Basic"
+      ],
+      "hp": "50",
+      "types": [
+        "Grass"
+      ],
+      "evolvesTo": [
+        "Kakuna"
+      ],
+      "attacks": [
+        {
+          "name": "Multiply",
+          "cost": [
+            "Grass"
+          ],
+          "convertedEnergyCost": 1,
+          "damage": "",
+          "text": "Search your deck for Weedle and put it onto your Bench. Shuffle your deck afterward."
+        }
+      ],
+      "weaknesses": [
+        {
+          "type": "Fire",
+          "value": "×2"
+        }
+      ],
+      "retreatCost": [
+        "Colorless"
+      ],
+      "convertedRetreatCost": 1,
+      "set": {
+        "id": "xy5",
+        "name": "Primal Clash",
+        "series": "XY",
+        "printedTotal": 160,
+        "total": 160,
+        "legalities": {
+          "unlimited": "Legal",
+          "expanded": "Legal"
+        },
+        "ptcgoCode": "PRC",
+        "releaseDate": "2015/02/04",
+        "updatedAt": "2020/05/01 16:06:00",
+        "images": {
+          "symbol": "https://images.pokemontcg.io/xy5/symbol.png",
+          "logo": "https://images.pokemontcg.io/xy5/logo.png"
+        }
+      },
+      "number": "1",
+      "artist": "Midori Harada",
+      "rarity": "Common",
+      "flavorText": "Its poison stinger is very powerful. Its bright-colored body is intended to warn off its enemies.",
+      "nationalPokedexNumbers": [
+        13
+      ],
+      "legalities": {
+        "unlimited": "Legal",
+        "expanded": "Legal"
+      },
+      "images": {
+        "small": "https://images.pokemontcg.io/xy5/1.png",
+        "large": "https://images.pokemontcg.io/xy5/1_hires.png"
+      },
+      "tcgplayer": {
+        "url": "https://prices.pokemontcg.io/tcgplayer/xy5-1",
+        "updatedAt": "2021/03/12",
+        "prices": {
+          "normal": {
+            "low": 0.04,
+            "mid": 0.23,
+            "high": 1.0,
+            "market": 0.1,
+            "directLow": 0.07
+          },
+          "reverseHolofoil": {
+            "low": 0.15,
+            "mid": 0.37,
+            "high": 1.95,
+            "market": 0.2,
+            "directLow": 0.2
+          }
+        }
+      }
+    },
+    {
+      "id": "ex7-1",
+      "name": "Azumarill",
+      "supertype": "Pokémon",
+      "subtypes": [
+        "Stage 1"
+      ],
+      "hp": "80",
+      "types": [
+        "Water"
+      ],
+      "evolvesFrom": "Marill",
+      "abilities": [
+        {
+          "name": "Froth",
+          "text": "Once during your turn, when you play Azumarill from your hand to evolve 1 of your Active Pokémon, you may use this power. Each Defending Pokémon is now Paralyzed.",
+          "type": "Poké-Power"
+        }
+      ],
+      "attacks": [
+        {
+          "name": "Water Punch",
+          "cost": [
+            "Water",
+            "Colorless"
+          ],
+          "convertedEnergyCost": 2,
+          "damage": "20+",
+          "text": "Flip a coin for each Water Energy attached to Azumarill. This attack does 20 damage plus 20 more damage for each heads."
+        }
+      ],
+      "weaknesses": [
+        {
+          "type": "Lightning",
+          "value": "×2"
+        }
+      ],
+      "retreatCost": [
+        "Colorless"
+      ],
+      "convertedRetreatCost": 1,
+      "set": {
+        "id": "ex7",
+        "name": "Team Rocket Returns",
+        "series": "EX",
+        "printedTotal": 109,
+        "total": 109,
+        "legalities": {
+          "unlimited": "Legal"
+        },
+        "ptcgoCode": "TRR",
+        "releaseDate": "2004/11/01",
+        "updatedAt": "2019/01/28 16:44:00",
+        "images": {
+          "symbol": "https://images.pokemontcg.io/ex7/symbol.png",
+          "logo": "https://images.pokemontcg.io/ex7/logo.png"
+        }
+      },
+      "number": "1",
+      "artist": "Sumiyoshi Kizuki",
+      "rarity": "Rare Holo",
+      "nationalPokedexNumbers": [
+        184
+      ],
+      "legalities": {
+        "unlimited": "Legal"
+      },
+      "images": {
+        "small": "https://images.pokemontcg.io/ex7/1.png",
+        "large": "https://images.pokemontcg.io/ex7/1_hires.png"
+      },
+      "tcgplayer": {
+        "url": "https://prices.pokemontcg.io/tcgplayer/ex7-1",
+        "updatedAt": "2021/03/12",
+        "prices": {
+          "holofoil": {
+            "low": 1.0,
+            "mid": 3.6,
+            "high": 8.49,
+            "market": 8.33,
+            "directLow": null
+          },
+          "reverseHolofoil": {
+            "low": 5.44,
+            "mid": 7.02,
+            "high": 8.99,
+            "market": 8.88,
+            "directLow": null
+          }
+        }
+      }
+    },
+    {
+      "id": "ecard2-H1",
+      "name": "Ampharos",
+      "supertype": "Pokémon",
+      "subtypes": [
+        "Stage 2"
+      ],
+      "hp": "100",
+      "types": [
+        "Lightning"
+      ],
+      "evolvesFrom": "Flaaffy",
+      "attacks": [
+        {
+          "name": "Thundershock",
+          "cost": [
+            "Lightning"
+          ],
+          "convertedEnergyCost": 1,
+          "damage": "20",
+          "text": "Flip a coin. If heads, the Defending Pokémon is now Paralyzed."
+        },
+        {
+          "name": "Reflect Energy",
+          "cost": [
+            "Lightning",
+            "Lightning",
+            "Colorless"
+          ],
+          "convertedEnergyCost": 3,
+          "damage": "50",
+          "text": "If you have any Benched Pokémon and if there are any basic Energy cards attached to Ampharos, take 1 of those Energy cards and attach it to 1 of those Pokémon."
+        }
+      ],
+      "weaknesses": [
+        {
+          "type": "Fighting",
+          "value": "×2"
+        }
+      ],
+      "retreatCost": [
+        "Colorless",
+        "Colorless"
+      ],
+      "convertedRetreatCost": 2,
+      "set": {
+        "id": "ecard2",
+        "name": "Aquapolis",
+        "series": "E-Card",
+        "printedTotal": 186,
+        "total": 186,
+        "legalities": {
+          "unlimited": "Legal"
+        },
+        "ptcgoCode": "AQ",
+        "releaseDate": "2003/01/15",
+        "updatedAt": "2020/08/14 09:35:00",
+        "images": {
+          "symbol": "https://images.pokemontcg.io/ecard2/symbol.png",
+          "logo": "https://images.pokemontcg.io/ecard2/logo.png"
+        }
+      },
+      "number": "H1",
+      "artist": "Shin-ichi Yoshida",
+      "rarity": "Rare Holo",
+      "nationalPokedexNumbers": [
+        181
+      ],
+      "legalities": {
+        "unlimited": "Legal"
+      },
+      "images": {
+        "small": "https://images.pokemontcg.io/ecard2/H1.png",
+        "large": "https://images.pokemontcg.io/ecard2/H1_hires.png"
+      },
+      "tcgplayer": {
+        "url": "https://prices.pokemontcg.io/tcgplayer/ecard2-H1",
+        "updatedAt": "2021/03/12",
+        "prices": {
+          "holofoil": {
+            "low": 89.96,
+            "mid": 140.49,
+            "high": 141.91,
+            "market": 141.91,
+            "directLow": null
+          }
+        }
+      }
+    },
+    {
+      "id": "ex3-1",
+      "name": "Absol",
+      "supertype": "Pokémon",
+      "subtypes": [
+        "Basic"
+      ],
+      "hp": "70",
+      "types": [
+        "Darkness"
+      ],
+      "attacks": [
+        {
+          "name": "Bad News",
+          "cost": [
+            "Darkness"
+          ],
+          "convertedEnergyCost": 1,
+          "damage": "",
+          "text": "If the number of cards in your opponent's hand is at least 6, choose a number of cards there, without looking, until your opponent has 5 cards left. Have your opponent discard the cards you chose."
+        },
+        {
+          "name": "Prize Count",
+          "cost": [
+            "Darkness",
+            "Colorless"
+          ],
+          "convertedEnergyCost": 2,
+          "damage": "20+",
+          "text": "If you have more Prize cards left than your opponent, this attack does 20 damage plus 20 more damage."
+        }
+      ],
+      "weaknesses": [
+        {
+          "type": "Fighting",
+          "value": "×2"
+        }
+      ],
+      "resistances": [
+        {
+          "type": "Psychic",
+          "value": "-30"
+        }
+      ],
+      "retreatCost": [
+        "Colorless"
+      ],
+      "convertedRetreatCost": 1,
+      "set": {
+        "id": "ex3",
+        "name": "Dragon",
+        "series": "EX",
+        "printedTotal": 97,
+        "total": 97,
+        "legalities": {
+          "unlimited": "Legal"
+        },
+        "ptcgoCode": "DR",
+        "releaseDate": "2003/09/18",
+        "updatedAt": "2019/01/28 16:44:00",
+        "images": {
+          "symbol": "https://images.pokemontcg.io/ex3/symbol.png",
+          "logo": "https://images.pokemontcg.io/ex3/logo.png"
+        }
+      },
+      "number": "1",
+      "artist": "Naoyo Kimura",
+      "rarity": "Rare Holo",
+      "nationalPokedexNumbers": [
+        359
+      ],
+      "legalities": {
+        "unlimited": "Legal"
+      },
+      "images": {
+        "small": "https://images.pokemontcg.io/ex3/1.png",
+        "large": "https://images.pokemontcg.io/ex3/1_hires.png"
+      },
+      "tcgplayer": {
+        "url": "https://prices.pokemontcg.io/tcgplayer/ex3-1",
+        "updatedAt": "2021/03/12",
+        "prices": {
+          "holofoil": {
+            "low": 41.99,
+            "mid": 43.19,
+            "high": 44.0,
+            "market": 42.61,
+            "directLow": null
+          },
+          "reverseHolofoil": {
+            "low": 15.0,
+            "mid": 19.99,
+            "high": 35.0,
+            "market": 9.25,
+            "directLow": null
+          }
+        }
+      }
+    },
+    {
+      "id": "hgss4-1",
+      "name": "Aggron",
+      "supertype": "Pokémon",
+      "subtypes": [
+        "Stage 2"
+      ],
+      "hp": "140",
+      "types": [
+        "Metal"
+      ],
+      "evolvesFrom": "Lairon",
+      "attacks": [
+        {
+          "name": "Second Strike",
+          "cost": [
+            "Metal",
+            "Metal",
+            "Colorless"
+          ],
+          "convertedEnergyCost": 3,
+          "damage": "40",
+          "text": "If the Defending Pokémon already has any damage counters on it, this attack does 40 damage plus 40 more damage."
+        },
+        {
+          "name": "Guard Claw",
+          "cost": [
+            "Metal",
+            "Metal",
+            "Colorless",
+            "Colorless"
+          ],
+          "convertedEnergyCost": 4,
+          "damage": "60",
+          "text": "During your opponent's next turn, any damage done to Aggron by attacks is reduced by 20 (after applying Weakness and Resistance)."
+        }
+      ],
+      "weaknesses": [
+        {
+          "type": "Fire",
+          "value": "×2"
+        }
+      ],
+      "resistances": [
+        {
+          "type": "Psychic",
+          "value": "-20"
+        }
+      ],
+      "retreatCost": [
+        "Colorless",
+        "Colorless",
+        "Colorless",
+        "Colorless"
+      ],
+      "convertedRetreatCost": 4,
+      "set": {
+        "id": "hgss4",
+        "name": "HS—Triumphant",
+        "series": "HeartGold & SoulSilver",
+        "printedTotal": 102,
+        "total": 102,
+        "legalities": {
+          "unlimited": "Legal"
+        },
+        "ptcgoCode": "TM",
+        "releaseDate": "2010/11/03",
+        "updatedAt": "2018/03/04 10:35:00",
+        "images": {
+          "symbol": "https://images.pokemontcg.io/hgss4/symbol.png",
+          "logo": "https://images.pokemontcg.io/hgss4/logo.png"
+        }
+      },
+      "number": "1",
+      "artist": "Kagemaru Himeno",
+      "rarity": "Rare Holo",
+      "flavorText": "You can tell its age by the length of its iron horns. It claims an entire mountain as its territory.",
+      "nationalPokedexNumbers": [
+        306
+      ],
+      "legalities": {
+        "unlimited": "Legal"
+      },
+      "images": {
+        "small": "https://images.pokemontcg.io/hgss4/1.png",
+        "large": "https://images.pokemontcg.io/hgss4/1_hires.png"
+      },
+      "tcgplayer": {
+        "url": "https://prices.pokemontcg.io/tcgplayer/hgss4-1",
+        "updatedAt": "2021/03/12",
+        "prices": {
+          "holofoil": {
+            "low": 1.01,
+            "mid": 2.44,
+            "high": 5.0,
+            "market": 1.63,
+            "directLow": null
+          },
+          "reverseHolofoil": {
+            "low": 1.99,
+            "mid": 13.95,
+            "high": 168.9,
+            "market": 2.41,
+            "directLow": 13.95
+          }
+        }
+      }
+    },
+    {
+      "id": "ex12-1",
+      "name": "Aerodactyl",
+      "supertype": "Pokémon",
+      "subtypes": [
+        "Stage 1"
+      ],
+      "hp": "70",
+      "types": [
+        "Colorless"
+      ],
+      "evolvesFrom": "Mysterious Fossil",
+      "abilities": [
+        {
+          "name": "Reactive Protection",
+          "text": "Any damage done to Aerodactyl by attacks from your opponent's Pokémon is reduced by 10 for each React Energy card attached to Aerodactyl (after applying Weakness and Resistance).",
+          "type": "Poké-Body"
+        }
+      ],
+      "attacks": [
+        {
+          "name": "Power Blow",
+          "cost": [
+            "Colorless"
+          ],
+          "convertedEnergyCost": 1,
+          "damage": "10+",
+          "text": "Does 10 damage plus 10 more damage for each Energy attached to Aerodactyl."
+        },
+        {
+          "name": "Speed Stroke",
+          "cost": [
+            "Colorless",
+            "Colorless",
+            "Colorless"
+          ],
+          "convertedEnergyCost": 3,
+          "damage": "40",
+          "text": "During your opponent's next turn, prevent all effects, including damage, done to Aerodactyl by attacks from your opponent's Pokémon-ex."
+        }
+      ],
+      "weaknesses": [
+        {
+          "type": "Lightning",
+          "value": "×2"
+        }
+      ],
+      "resistances": [
+        {
+          "type": "Fighting",
+          "value": "-30"
+        }
+      ],
+      "set": {
+        "id": "ex12",
+        "name": "Legend Maker",
+        "series": "EX",
+        "printedTotal": 92,
+        "total": 93,
+        "legalities": {
+          "unlimited": "Legal"
+        },
+        "ptcgoCode": "LM",
+        "releaseDate": "2006/02/01",
+        "updatedAt": "2018/03/04 10:35:00",
+        "images": {
+          "symbol": "https://images.pokemontcg.io/ex12/symbol.png",
+          "logo": "https://images.pokemontcg.io/ex12/logo.png"
+        }
+      },
+      "number": "1",
+      "artist": "Hajime Kusajima",
+      "rarity": "Rare Holo",
+      "nationalPokedexNumbers": [
+        142
+      ],
+      "legalities": {
+        "unlimited": "Legal"
+      },
+      "images": {
+        "small": "https://images.pokemontcg.io/ex12/1.png",
+        "large": "https://images.pokemontcg.io/ex12/1_hires.png"
+      },
+      "tcgplayer": {
+        "url": "https://prices.pokemontcg.io/tcgplayer/ex12-1",
+        "updatedAt": "2021/03/12",
+        "prices": {
+          "holofoil": {
+            "low": 10.0,
+            "mid": 14.04,
+            "high": 34.95,
+            "market": 15.45,
+            "directLow": null
+          },
+          "reverseHolofoil": {
+            "low": 45.0,
+            "mid": 45.0,
+            "high": 45.0,
+            "market": 4.96,
+            "directLow": null
+          }
+        }
+      }
+    }
+  ],
+  "page": 1,
+  "pageSize": 10,
+  "count": 10,
+  "totalCount": 13223
 }

--- a/tests/lib/fixtures/rarities/all.json
+++ b/tests/lib/fixtures/rarities/all.json
@@ -1,0 +1,27 @@
+{
+  "data": [
+    "Amazing Rare",
+    "Common",
+    "LEGEND",
+    "Promo",
+    "Rare",
+    "Rare ACE",
+    "Rare BREAK",
+    "Rare Holo",
+    "Rare Holo EX",
+    "Rare Holo GX",
+    "Rare Holo LV.X",
+    "Rare Holo Star",
+    "Rare Holo V",
+    "Rare Holo VMAX",
+    "Rare Prime",
+    "Rare Prism Star",
+    "Rare Rainbow",
+    "Rare Secret",
+    "Rare Shining",
+    "Rare Shiny",
+    "Rare Shiny GX",
+    "Rare Ultra",
+    "Uncommon"
+  ]
+}

--- a/tests/lib/fixtures/sets/filtered.json
+++ b/tests/lib/fixtures/sets/filtered.json
@@ -1,104 +1,311 @@
 {
-    "sets": [
-        {
-            "code": "bwp",
-            "ptcgoCode": "PR",
-            "name": "BW Black Star Promos",
-            "series": "Black & White",
-            "totalCards": 101,
-            "standardLegal": true,
-            "releaseDate": "03/01/2011",
-            "symbolUrl": "https://images.pokemontcg.io/bwp/symbol.png"
-        },
-        {
-            "code": "xy5",
-            "ptcgoCode": "PRC",
-            "name": "Primal Clash",
-            "series": "XY",
-            "totalCards": 160,
-            "standardLegal": true,
-            "releaseDate": "02/04/2015",
-            "symbolUrl": "https://images.pokemontcg.io/xy5/symbol.png"
-        },
-        {
-            "code": "dc1",
-            "ptcgoCode": "DCR",
-            "name": "Double Crisis",
-            "series": "XY",
-            "totalCards": 34,
-            "standardLegal": true,
-            "releaseDate": "03/25/2015",
-            "symbolUrl": "https://images.pokemontcg.io/dc1/symbol.png"
-        },
-        {
-            "code": "xy6",
-            "ptcgoCode": "ROS",
-            "name": "Roaring Skies",
-            "series": "XY",
-            "totalCards": 108,
-            "standardLegal": true,
-            "releaseDate": "05/06/2015",
-            "symbolUrl": "https://images.pokemontcg.io/xy6/symbol.png"
-        },
-        {
-            "code": "xy7",
-            "ptcgoCode": "AOR",
-            "name": "Ancient Origins",
-            "series": "XY",
-            "totalCards": 98,
-            "standardLegal": true,
-            "releaseDate": "08/12/2015",
-            "symbolUrl": "https://images.pokemontcg.io/xy7/symbol.png"
-        },
-        {
-            "code": "xy8",
-            "ptcgoCode": "BKT",
-            "name": "BREAKthrough",
-            "series": "XY",
-            "totalCards": 162,
-            "standardLegal": true,
-            "releaseDate": "11/04/2015",
-            "symbolUrl": "https://images.pokemontcg.io/xy8/symbol.png"
-        },
-        {
-            "code": "xy9",
-            "ptcgoCode": "BKP",
-            "name": "BREAKpoint",
-            "series": "XY",
-            "totalCards": 123,
-            "standardLegal": true,
-            "releaseDate": "02/03/2016",
-            "symbolUrl": "https://images.pokemontcg.io/xy9/symbol.png"
-        },
-        {
-            "code": "g1",
-            "ptcgoCode": "GEN",
-            "name": "Generations",
-            "series": "XY",
-            "totalCards": 115,
-            "standardLegal": true,
-            "releaseDate": "02/22/2016",
-            "symbolUrl": "https://images.pokemontcg.io/g1/symbol.png"
-        },
-        {
-            "code": "xy10",
-            "ptcgoCode": "FCO",
-            "name": "Fates Collide",
-            "series": "XY",
-            "totalCards": 124,
-            "standardLegal": true,
-            "releaseDate": "05/02/2016",
-            "symbolUrl": "https://images.pokemontcg.io/xy10/symbol.png"
-        },
-        {
-            "code": "xy11",
-            "ptcgoCode": "STS",
-            "name": "Steam Siege",
-            "series": "XY",
-            "totalCards": 114,
-            "standardLegal": true,
-            "releaseDate": "08/03/2016",
-            "symbolUrl": "https://images.pokemontcg.io/xy11/symbol.png"
-        }
-    ]
+  "data": [
+    {
+      "id": "smp",
+      "name": "SM Black Star Promos",
+      "series": "Sun & Moon",
+      "printedTotal": 156,
+      "total": 156,
+      "legalities": {
+        "unlimited": "Legal",
+        "standard": "Legal",
+        "expanded": "Legal"
+      },
+      "ptcgoCode": "PR-SM",
+      "releaseDate": "2017/02/03",
+      "updatedAt": "2020/05/01 16:06:00",
+      "images": {
+        "symbol": "https://images.pokemontcg.io/smp/symbol.png",
+        "logo": "https://images.pokemontcg.io/smp/logo.png"
+      }
+    },
+    {
+      "id": "sm9",
+      "name": "Team Up",
+      "series": "Sun & Moon",
+      "printedTotal": 181,
+      "total": 196,
+      "legalities": {
+        "unlimited": "Legal",
+        "standard": "Legal",
+        "expanded": "Legal"
+      },
+      "ptcgoCode": "TEU",
+      "releaseDate": "2019/02/01",
+      "updatedAt": "2020/08/14 09:35:00",
+      "images": {
+        "symbol": "https://images.pokemontcg.io/sm9/symbol.png",
+        "logo": "https://images.pokemontcg.io/sm9/logo.png"
+      }
+    },
+    {
+      "id": "det1",
+      "name": "Detective Pikachu",
+      "series": "Sun & Moon",
+      "printedTotal": 18,
+      "total": 18,
+      "legalities": {
+        "unlimited": "Legal",
+        "standard": "Legal",
+        "expanded": "Legal"
+      },
+      "ptcgoCode": "DET",
+      "releaseDate": "2019/04/05",
+      "updatedAt": "2019/04/25 22:26:00",
+      "images": {
+        "symbol": "https://images.pokemontcg.io/det1/symbol.png",
+        "logo": "https://images.pokemontcg.io/det1/logo.png"
+      }
+    },
+    {
+      "id": "sm10",
+      "name": "Unbroken Bonds",
+      "series": "Sun & Moon",
+      "printedTotal": 214,
+      "total": 234,
+      "legalities": {
+        "unlimited": "Legal",
+        "standard": "Legal",
+        "expanded": "Legal"
+      },
+      "ptcgoCode": "UNB",
+      "releaseDate": "2019/05/03",
+      "updatedAt": "2020/08/14 09:35:00",
+      "images": {
+        "symbol": "https://images.pokemontcg.io/sm10/symbol.png",
+        "logo": "https://images.pokemontcg.io/sm10/logo.png"
+      }
+    },
+    {
+      "id": "sm11",
+      "name": "Unified Minds",
+      "series": "Sun & Moon",
+      "printedTotal": 236,
+      "total": 258,
+      "legalities": {
+        "unlimited": "Legal",
+        "standard": "Legal",
+        "expanded": "Legal"
+      },
+      "ptcgoCode": "UNM",
+      "releaseDate": "2019/08/02",
+      "updatedAt": "2020/09/25 10:09:00",
+      "images": {
+        "symbol": "https://images.pokemontcg.io/sm11/symbol.png",
+        "logo": "https://images.pokemontcg.io/sm11/logo.png"
+      }
+    },
+    {
+      "id": "sm115",
+      "name": "Hidden Fates",
+      "series": "Sun & Moon",
+      "printedTotal": 68,
+      "total": 69,
+      "legalities": {
+        "unlimited": "Legal",
+        "standard": "Legal",
+        "expanded": "Legal"
+      },
+      "ptcgoCode": "HIF",
+      "releaseDate": "2019/08/23",
+      "updatedAt": "2019/08/23 15:59:00",
+      "images": {
+        "symbol": "https://images.pokemontcg.io/sm115/symbol.png",
+        "logo": "https://images.pokemontcg.io/sm115/logo.png"
+      }
+    },
+    {
+      "id": "sma",
+      "name": "Shiny Vault",
+      "series": "Sun & Moon",
+      "printedTotal": 94,
+      "total": 94,
+      "legalities": {
+        "unlimited": "Legal",
+        "standard": "Legal",
+        "expanded": "Legal"
+      },
+      "releaseDate": "2019/08/23",
+      "updatedAt": "2020/05/01 16:06:00",
+      "images": {
+        "symbol": "https://images.pokemontcg.io/sma/symbol.png",
+        "logo": "https://images.pokemontcg.io/sma/logo.png"
+      }
+    },
+    {
+      "id": "sm12",
+      "name": "Cosmic Eclipse",
+      "series": "Sun & Moon",
+      "printedTotal": 236,
+      "total": 271,
+      "legalities": {
+        "unlimited": "Legal",
+        "standard": "Legal",
+        "expanded": "Legal"
+      },
+      "ptcgoCode": "CEC",
+      "releaseDate": "2019/11/01",
+      "updatedAt": "2020/08/14 09:35:00",
+      "images": {
+        "symbol": "https://images.pokemontcg.io/sm12/symbol.png",
+        "logo": "https://images.pokemontcg.io/sm12/logo.png"
+      }
+    },
+    {
+      "id": "swshp",
+      "name": "SWSH Black Star Promos",
+      "series": "Sword & Shield",
+      "printedTotal": 74,
+      "total": 74,
+      "legalities": {
+        "unlimited": "Legal",
+        "standard": "Legal",
+        "expanded": "Legal"
+      },
+      "ptcgoCode": "PR-SW",
+      "releaseDate": "2019/11/15",
+      "updatedAt": "2020/11/15 10:00:00",
+      "images": {
+        "symbol": "https://images.pokemontcg.io/swshp/symbol.png",
+        "logo": "https://images.pokemontcg.io/swshp/logo.png"
+      }
+    },
+    {
+      "id": "swsh1",
+      "name": "Sword & Shield",
+      "series": "Sword & Shield",
+      "printedTotal": 202,
+      "total": 216,
+      "legalities": {
+        "unlimited": "Legal",
+        "standard": "Legal",
+        "expanded": "Legal"
+      },
+      "ptcgoCode": "SSH",
+      "releaseDate": "2020/02/07",
+      "updatedAt": "2020/08/14 09:35:00",
+      "images": {
+        "symbol": "https://images.pokemontcg.io/swsh1/symbol.png",
+        "logo": "https://images.pokemontcg.io/swsh1/logo.png"
+      }
+    },
+    {
+      "id": "swsh2",
+      "name": "Rebel Clash",
+      "series": "Sword & Shield",
+      "printedTotal": 192,
+      "total": 209,
+      "legalities": {
+        "unlimited": "Legal",
+        "standard": "Legal",
+        "expanded": "Legal"
+      },
+      "ptcgoCode": "RCL",
+      "releaseDate": "2020/05/01",
+      "updatedAt": "2020/09/25 10:09:00",
+      "images": {
+        "symbol": "https://images.pokemontcg.io/swsh2/symbol.png",
+        "logo": "https://images.pokemontcg.io/swsh2/logo.png"
+      }
+    },
+    {
+      "id": "swsh3",
+      "name": "Darkness Ablaze",
+      "series": "Sword & Shield",
+      "printedTotal": 189,
+      "total": 201,
+      "legalities": {
+        "unlimited": "Legal",
+        "standard": "Legal",
+        "expanded": "Legal"
+      },
+      "ptcgoCode": "DAA",
+      "releaseDate": "2020/08/14",
+      "updatedAt": "2020/10/25 13:45:00",
+      "images": {
+        "symbol": "https://images.pokemontcg.io/swsh3/symbol.png",
+        "logo": "https://images.pokemontcg.io/swsh3/logo.png"
+      }
+    },
+    {
+      "id": "swsh35",
+      "name": "Champion's Path",
+      "series": "Sword & Shield",
+      "printedTotal": 73,
+      "total": 80,
+      "legalities": {
+        "unlimited": "Legal",
+        "standard": "Legal",
+        "expanded": "Legal"
+      },
+      "ptcgoCode": "CPA",
+      "releaseDate": "2020/09/25",
+      "updatedAt": "2020/10/25 13:45:00",
+      "images": {
+        "symbol": "https://images.pokemontcg.io/swsh35/symbol.png",
+        "logo": "https://images.pokemontcg.io/swsh35/logo.png"
+      }
+    },
+    {
+      "id": "swsh4",
+      "name": "Vivid Voltage",
+      "series": "Sword & Shield",
+      "printedTotal": 185,
+      "total": 203,
+      "legalities": {
+        "unlimited": "Legal",
+        "standard": "Legal",
+        "expanded": "Legal"
+      },
+      "ptcgoCode": "VIV",
+      "releaseDate": "2020/11/13",
+      "updatedAt": "2020/11/13 16:20:00",
+      "images": {
+        "symbol": "https://images.pokemontcg.io/swsh4/symbol.png",
+        "logo": "https://images.pokemontcg.io/swsh4/logo.png"
+      }
+    },
+    {
+      "id": "swsh45",
+      "name": "Shining Fates",
+      "series": "Sword & Shield",
+      "printedTotal": 72,
+      "total": 73,
+      "legalities": {
+        "unlimited": "Legal",
+        "standard": "Legal",
+        "expanded": "Legal"
+      },
+      "ptcgoCode": "SHF",
+      "releaseDate": "2021/02/19",
+      "updatedAt": "2021/02/24 16:17:00",
+      "images": {
+        "symbol": "https://images.pokemontcg.io/swsh45/symbol.png",
+        "logo": "https://images.pokemontcg.io/swsh45/logo.png"
+      }
+    },
+    {
+      "id": "swsh45sv",
+      "name": "Shiny Vault",
+      "series": "Sword & Shield",
+      "printedTotal": 122,
+      "total": 122,
+      "legalities": {
+        "unlimited": "Legal",
+        "standard": "Legal",
+        "expanded": "Legal"
+      },
+      "ptcgoCode": "SHF",
+      "releaseDate": "2021/02/19",
+      "updatedAt": "2021/02/24 16:17:00",
+      "images": {
+        "symbol": "https://images.pokemontcg.io/swsh45sv/symbol.png",
+        "logo": "https://images.pokemontcg.io/swsh45sv/logo.png"
+      }
+    }
+  ],
+  "page": 1,
+  "pageSize": 250,
+  "count": 16,
+  "totalCount": 16
 }

--- a/tests/lib/fixtures/sets/find.json
+++ b/tests/lib/fixtures/sets/find.json
@@ -1,14 +1,20 @@
 {
-    "set": {
-        "code": "g1",
-        "ptcgoCode": "GEN",
-        "name": "Generations",
-        "series": "XY",
-        "totalCards": 115,
-        "standardLegal": true,
-        "expandedLegal": true,
-        "releaseDate": "02/22/2016",
-        "symbolUrl": "https://images.pokemontcg.io/g1/symbol.png",
-        "logoUrl": "https://images.pokemontcg.io/g1/logo.png"
+  "data": {
+    "id": "g1",
+    "name": "Generations",
+    "series": "XY",
+    "printedTotal": 115,
+    "total": 115,
+    "legalities": {
+      "unlimited": "Legal",
+      "expanded": "Legal"
+    },
+    "ptcgoCode": "GEN",
+    "releaseDate": "2016/02/22",
+    "updatedAt": "2020/08/14 09:35:00",
+    "images": {
+      "symbol": "https://images.pokemontcg.io/g1/symbol.png",
+      "logo": "https://images.pokemontcg.io/g1/logo.png"
     }
+  }
 }

--- a/tests/lib/fixtures/sets/page.json
+++ b/tests/lib/fixtures/sets/page.json
@@ -1,104 +1,178 @@
 {
-    "sets": [
-        {
-            "code": "base1",
-            "ptcgoCode": "BS",
-            "name": "Base",
-            "series": "Base",
-            "totalCards": 102,
-            "standardLegal": false,
-            "releaseDate": "01/09/1999",
-            "symbolUrl": "https://images.pokemontcg.io/base1/symbol.png"
-        },
-        {
-            "code": "base2",
-            "ptcgoCode": "JU",
-            "name": "Jungle",
-            "series": "Base",
-            "totalCards": 64,
-            "standardLegal": false,
-            "releaseDate": "06/16/1999",
-            "symbolUrl":"https://images.pokemontcg.io/base2/symbol.png"
-        },
-        {
-            "code": "base3",
-            "ptcgoCode": "FO",
-            "name": "Fossil",
-            "series": "Base",
-            "totalCards": 62,
-            "standardLegal": false,
-            "releaseDate": "10/10/1999",
-            "symbolUrl": "https://images.pokemontcg.io/base3/symbol.png"
-        },
-        {
-            "code": "base5",
-            "ptcgoCode": "TR",
-            "name": "Team Rocket",
-            "series": "Base",
-            "totalCards": 83,
-            "standardLegal": false,
-            "releaseDate": "04/24/2000",
-            "symbolUrl": "https://images.pokemontcg.io/base5/symbol.png"
-        },
-        {
-            "code": "gym1",
-            "ptcgoCode": "G1",
-            "name": "Gym Heroes",
-            "series": "Gym",
-            "totalCards": 132,
-            "standardLegal": false,
-            "releaseDate": "08/14/2000",
-            "symbolUrl": "https://images.pokemontcg.io/gym1/symbol.png"
-        },
-        {
-            "code": "gym2",
-            "ptcgoCode": "G2",
-            "name": "Gym Challenge",
-            "series": "Gym",
-            "totalCards": 132,
-            "standardLegal": false,
-            "releaseDate": "10/16/2000",
-            "symbolUrl": "https://images.pokemontcg.io/gym2/symbol.png"
-        },
-        {
-            "code": "neo1",
-            "ptcgoCode": "N1",
-            "name": "Neo Genesis",
-            "series": "Neo",
-            "totalCards": 111,
-            "standardLegal": false,
-            "releaseDate": "12/16/2000",
-            "symbolUrl": "https://images.pokemontcg.io/neo1/symbol.png"
-        },
-        {
-            "code": "neo2",
-            "ptcgoCode": "N2",
-            "name": "Neo Discovery",
-            "series": "Neo",
-            "totalCards": 75,
-            "standardLegal": false,
-            "releaseDate": "06/01/2001",
-            "symbolUrl": "https://images.pokemontcg.io/neo2/symbol.png"
-        },
-        {
-            "code": "neo3",
-            "ptcgoCode": "N3",
-            "name": "Neo Revelation",
-            "series": "Neo",
-            "totalCards": 66,
-            "standardLegal": false,
-            "releaseDate": "09/21/2001",
-            "symbolUrl": "https://images.pokemontcg.io/neo3/symbol.png"
-        },
-        {
-            "code": "neo4",
-            "ptcgoCode": "N4",
-            "name": "Neo Destiny",
-            "series": "Neo",
-            "totalCards": 113,
-            "standardLegal": false,
-            "releaseDate": "02/28/2002",
-            "symbolUrl": "https://images.pokemontcg.io/neo4/symbol.png"
-        }
-    ]
+  "data": [
+    {
+      "id": "base1",
+      "name": "Base",
+      "series": "Base",
+      "printedTotal": 102,
+      "total": 102,
+      "legalities": {
+        "unlimited": "Legal"
+      },
+      "ptcgoCode": "BS",
+      "releaseDate": "1999/01/09",
+      "updatedAt": "2020/08/14 09:35:00",
+      "images": {
+        "symbol": "https://images.pokemontcg.io/base1/symbol.png",
+        "logo": "https://images.pokemontcg.io/base1/logo.png"
+      }
+    },
+    {
+      "id": "base2",
+      "name": "Jungle",
+      "series": "Base",
+      "printedTotal": 64,
+      "total": 64,
+      "legalities": {
+        "unlimited": "Legal"
+      },
+      "ptcgoCode": "JU",
+      "releaseDate": "1999/06/16",
+      "updatedAt": "2020/08/14 09:35:00",
+      "images": {
+        "symbol": "https://images.pokemontcg.io/base2/symbol.png",
+        "logo": "https://images.pokemontcg.io/base2/logo.png"
+      }
+    },
+    {
+      "id": "basep",
+      "name": "Wizards Black Star Promos",
+      "series": "Base",
+      "printedTotal": 53,
+      "total": 53,
+      "legalities": {
+        "unlimited": "Legal"
+      },
+      "ptcgoCode": "PR",
+      "releaseDate": "1999/07/01",
+      "updatedAt": "2020/08/14 09:35:00",
+      "images": {
+        "symbol": "https://images.pokemontcg.io/basep/symbol.png",
+        "logo": "https://images.pokemontcg.io/basep/logo.png"
+      }
+    },
+    {
+      "id": "base3",
+      "name": "Fossil",
+      "series": "Base",
+      "printedTotal": 62,
+      "total": 62,
+      "legalities": {
+        "unlimited": "Legal"
+      },
+      "ptcgoCode": "FO",
+      "releaseDate": "1999/10/10",
+      "updatedAt": "2020/08/14 09:35:00",
+      "images": {
+        "symbol": "https://images.pokemontcg.io/base3/symbol.png",
+        "logo": "https://images.pokemontcg.io/base3/logo.png"
+      }
+    },
+    {
+      "id": "base4",
+      "name": "Base Set 2",
+      "series": "Base",
+      "printedTotal": 130,
+      "total": 130,
+      "legalities": {
+        "unlimited": "Legal"
+      },
+      "ptcgoCode": "B2",
+      "releaseDate": "2000/02/24",
+      "updatedAt": "2020/08/14 09:35:00",
+      "images": {
+        "symbol": "https://images.pokemontcg.io/base4/symbol.png",
+        "logo": "https://images.pokemontcg.io/base4/logo.png"
+      }
+    },
+    {
+      "id": "base5",
+      "name": "Team Rocket",
+      "series": "Base",
+      "printedTotal": 83,
+      "total": 83,
+      "legalities": {
+        "unlimited": "Legal"
+      },
+      "ptcgoCode": "TR",
+      "releaseDate": "2000/04/24",
+      "updatedAt": "2020/08/14 09:35:00",
+      "images": {
+        "symbol": "https://images.pokemontcg.io/base5/symbol.png",
+        "logo": "https://images.pokemontcg.io/base5/logo.png"
+      }
+    },
+    {
+      "id": "gym1",
+      "name": "Gym Heroes",
+      "series": "Gym",
+      "printedTotal": 132,
+      "total": 132,
+      "legalities": {
+        "unlimited": "Legal"
+      },
+      "ptcgoCode": "G1",
+      "releaseDate": "2000/08/14",
+      "updatedAt": "2020/08/14 09:35:00",
+      "images": {
+        "symbol": "https://images.pokemontcg.io/gym1/symbol.png",
+        "logo": "https://images.pokemontcg.io/gym1/logo.png"
+      }
+    },
+    {
+      "id": "gym2",
+      "name": "Gym Challenge",
+      "series": "Gym",
+      "printedTotal": 132,
+      "total": 132,
+      "legalities": {
+        "unlimited": "Legal"
+      },
+      "ptcgoCode": "G2",
+      "releaseDate": "2000/10/16",
+      "updatedAt": "2020/08/14 09:35:00",
+      "images": {
+        "symbol": "https://images.pokemontcg.io/gym2/symbol.png",
+        "logo": "https://images.pokemontcg.io/gym2/logo.png"
+      }
+    },
+    {
+      "id": "neo1",
+      "name": "Neo Genesis",
+      "series": "Neo",
+      "printedTotal": 111,
+      "total": 111,
+      "legalities": {
+        "unlimited": "Legal"
+      },
+      "ptcgoCode": "N1",
+      "releaseDate": "2000/12/16",
+      "updatedAt": "2020/08/14 09:35:00",
+      "images": {
+        "symbol": "https://images.pokemontcg.io/neo1/symbol.png",
+        "logo": "https://images.pokemontcg.io/neo1/logo.png"
+      }
+    },
+    {
+      "id": "neo2",
+      "name": "Neo Discovery",
+      "series": "Neo",
+      "printedTotal": 75,
+      "total": 75,
+      "legalities": {
+        "unlimited": "Legal"
+      },
+      "ptcgoCode": "N2",
+      "releaseDate": "2001/06/01",
+      "updatedAt": "2020/08/14 09:35:00",
+      "images": {
+        "symbol": "https://images.pokemontcg.io/neo2/symbol.png",
+        "logo": "https://images.pokemontcg.io/neo2/logo.png"
+      }
+    }
+  ],
+  "page": 1,
+  "pageSize": 10,
+  "count": 10,
+  "totalCount": 121
 }

--- a/tests/lib/fixtures/subtypes/all.json
+++ b/tests/lib/fixtures/subtypes/all.json
@@ -1,21 +1,27 @@
 {
-    "subtypes": [
-        "MEGA",
-        "Item",
-        "Level Up",
-        "Supporter",
-        "",
-        "EX",
-        "Technical Machine",
-        "Rocket's Secret Machine",
-        "Stadium",
-        "Restored",
-        "Stage 1",
-        "LEGEND",
-        "BREAK",
-        "Pokémon Tool",
-        "Stage 2",
-        "Special",
-        "Basic"
-    ]
+  "data": [
+    "BREAK",
+    "Baby",
+    "Basic",
+    "EX",
+    "GX",
+    "Goldenrod Game Corner",
+    "Item",
+    "LEGEND",
+    "Level-Up",
+    "MEGA",
+    "Pokémon Tool",
+    "Pokémon Tool F",
+    "Restored",
+    "Rocket's Secret Machine",
+    "Special",
+    "Stadium",
+    "Stage 1",
+    "Stage 2",
+    "Supporter",
+    "TAG TEAM",
+    "Technical Machine",
+    "V",
+    "VMAX"
+  ]
 }

--- a/tests/lib/fixtures/supertypes/all.json
+++ b/tests/lib/fixtures/supertypes/all.json
@@ -1,7 +1,7 @@
 {
-    "supertypes": [
-        "Pokémon",
-        "Energy",
-        "Trainer"
-    ]
+  "data": [
+    "Energy",
+    "Pokémon",
+    "Trainer"
+  ]
 }

--- a/tests/lib/fixtures/types/all.json
+++ b/tests/lib/fixtures/types/all.json
@@ -1,16 +1,15 @@
 {
-    "types": [
-        "Colorless",
-        "Dark",
-        "Darkness",
-        "Dragon",
-        "Fairy",
-        "Fighting",
-        "Fire",
-        "Grass",
-        "Lightning",
-        "Metal",
-        "Psychic",
-        "Water"
-    ]
+  "data": [
+    "Colorless",
+    "Darkness",
+    "Dragon",
+    "Fairy",
+    "Fighting",
+    "Fire",
+    "Grass",
+    "Lightning",
+    "Metal",
+    "Psychic",
+    "Water"
+  ]
 }


### PR DESCRIPTION
### Overview
In order to support v2, the following changes must be supported. [See the official documentation for more details](https://docs.pokemontcg.io/#documentationmigration). I propose the architecture remains the same while v2 is implemented.

### General
- [x] Update PHP requirement to [supported versions](https://www.php.net/supported-versions.php) - `7.4` & `8.0`
- [x] Add support for `X-Api-Key` header
- [x] Response data now lives inside a `data` field instead of `cards` , `sets`, `subtypes`, etc
- [x] Update README.md

### Pagination
- [x] Support `page` and `pageSize` for requests
- [x] Support `page`, `pageSize`, `count` and `totalCount` in responses
- [x] Add pagination tests

### Cards
- [x] Replace `subtype` with `subtypes` array
- [x] Replace `ability` with `abilities` array
- [x] Replace `nationalPokedexNumber` with `nationalPokedexNumbers` array
- [x] Replace `imageUrl` and `imageHiRes` with `images` object
- [x] Replace `text` with `rules`
- [x] Add `legalities` object
- [x] Add `tcgplayer` object
- [x] Add `set` object
- [x] Add `flavorText` string
- [x] Add `evolvesTo` array
- [x]  Update Tests

### Sets
- [x] Replace `standardLegal` and `expandedLegal` with `legalities` object
- [x] Replace `totalCards` with `printedTotal`
- [x] Replace `symbolUrl` and `logoUrl` with `logos` object
- [x] Add `total` number
- [x] Update Tests

### Rarities
- [x] Add Rarity resource
- [x] Add Rarity tests