### PR TITLE
Add regulationMark property to Pokemon::Card model

### DIFF
--- a/src/Models/Card.php
+++ b/src/Models/Card.php
@@ -141,6 +141,11 @@ class Card extends Model
     private $cardmarket;
 
     /**
+     * @var string|null
+     */
+    private $regulationMark;
+
+    /**
      * @return string
      */
     public function getId(): string
@@ -554,6 +559,22 @@ class Card extends Model
     public function setCardmarket(?CardMarket $cardMarket): void
     {
         $this->cardmarket = $cardMarket;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRegulationMark(): string
+    {
+        return $this->regulationMark;
+    }
+
+    /**
+     * @param string $id
+     */
+    public function setRegulationMark(string $regulationMark)
+    {
+        $this->regulationMark = $regulationMark;
     }
 
 }

--- a/src/Models/Card.php
+++ b/src/Models/Card.php
@@ -564,7 +564,7 @@ class Card extends Model
     /**
      * @return string
      */
-    public function getRegulationMark(): string
+    public function getRegulationMark(): ?string
     {
         return $this->regulationMark;
     }
@@ -572,7 +572,7 @@ class Card extends Model
     /**
      * @param string $id
      */
-    public function setRegulationMark(string $regulationMark)
+    public function setRegulationMark(?string $regulationMark)
     {
         $this->regulationMark = $regulationMark;
     }


### PR DESCRIPTION
Hi everyone!
I was using the SDK and I found this issue: https://github.com/PokemonTCG/pokemon-tcg-sdk-php/issues/15

I checked how to fix it and this is the pull request with the fix.

I hope it be helpful!